### PR TITLE
Vector2D methods and unit tests, Line2D analog of Line3D and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coverage.*
 *.psess
 *.vsp
 *.vspx
+*.boltdata
 
 # Caches
 _ReSharper*

--- a/src/Spatial/Euclidean/Line2D.cs
+++ b/src/Spatial/Euclidean/Line2D.cs
@@ -1,0 +1,176 @@
+﻿using System;
+
+namespace MathNet.Spatial.Euclidean
+{
+    /// <summary>
+    /// This structure represents a line between two points in 2-space.  It allows for operations such as 
+    /// computing the length, direction, projections to, compairisons, and shifting by a vector.  
+    /// </summary>
+    public struct Line2D : IEquatable<Line2D>
+    {
+        private Vector2D _direction;
+        private double _length;
+
+        /// <summary>
+        /// The starting point of the line
+        /// </summary>
+        public readonly Point2D StartPoint;
+
+        /// <summary>
+        /// The end point of the line
+        /// </summary>
+        public readonly Point2D EndPoint;
+
+        /// <summary>
+        /// A double precision number representing the distance between the startpoint and endpoint
+        /// </summary>
+        public double Length
+        {
+            get
+            {
+                if (this._length < 0)
+                    ComputeLengthAndDirection();
+                return this._length;
+            }
+        }
+
+        /// <summary>
+        /// A normalized Vector2D representing the direction from the startpoint to the endpoint
+        /// </summary>
+        public Vector2D Direction
+        {
+            get
+            {
+                if (this._length < 0)
+                    ComputeLengthAndDirection();
+                return this._direction;
+            }
+        }
+
+        /// <summary>
+        /// Constructor for the Line2D, throws an error if the startpoint is equal to the 
+        /// endpoint.
+        /// </summary>
+        /// <param name="startPoint">the starting point of the line</param>
+        /// <param name="endPoint">the ending point of the line</param>
+        public Line2D(Point2D startPoint, Point2D endPoint)
+        {
+            this.StartPoint = startPoint;
+            this.EndPoint = endPoint;
+
+            if (this.StartPoint == this.EndPoint)
+            {
+                throw new ArgumentException("The Line2D starting and ending points cannot be identical");
+            }
+
+            // Initialize the length and direction for lazy loading
+            this._length = -1.0;
+            this._direction = new Vector2D();
+        }
+
+        /// <summary>
+        /// Compute and store the length and direction of the Line2D, used for lazy loading
+        /// </summary>
+        /// <returns></returns>
+        private void ComputeLengthAndDirection()
+        {
+            var vectorBetween = this.StartPoint.VectorTo(this.EndPoint);
+            this._length = vectorBetween.Length;
+            this._direction = vectorBetween.Normalize();
+        }
+
+        /// <summary>
+        /// Returns the shortest line between this line and a point.
+        /// </summary>
+        /// <param name="p">the point to create a line to</param>
+        /// <param name="mustStartBetweenAndEnd">If false the startpoint can extend beyond the start and endpoint of the line</param>
+        /// <returns></returns>
+        public Line2D LineTo(Point2D p, bool mustStartBetweenAndEnd)
+        {
+            Vector2D v = this.StartPoint.VectorTo(p);
+            double dotProduct = v.DotProduct(this.Direction);
+            if (mustStartBetweenAndEnd)
+            {
+                if (dotProduct < 0)
+                    dotProduct = 0;
+
+                double l = this.Length;
+                if (dotProduct > l)
+                    dotProduct = l;
+            }
+
+            Vector2D alongVector = dotProduct*this.Direction;
+            return new Line2D(this.StartPoint + alongVector, p);
+        }
+
+        # region Operators 
+
+        public static bool operator ==(Line2D left, Line2D right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Line2D left, Line2D right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static Line2D operator +(Vector2D offset, Line2D line)
+        {
+            return new Line2D(line.StartPoint + offset, line.EndPoint + offset);
+        }
+
+        public static Line2D operator +(Line2D line, Vector2D offset)
+        {
+            return offset + line;
+        }
+
+        public static Line2D operator -(Line2D line, Vector2D offset)
+        {
+            return line + (-offset);
+        }
+        
+        # endregion
+
+        # region Serialization and Deserialization
+        
+        public override string ToString()
+        {
+            return string.Format("StartPoint: {0}, EndPoint: {1}", this.StartPoint, this.EndPoint);
+        }
+
+        public static Line2D Parse(string startPointString, string endPointString)
+        {
+            return new Line2D(Point2D.Parse(startPointString), Point2D.Parse(endPointString));
+        }
+        
+        # endregion
+
+
+        # region Equality and Hash Code
+
+        public bool Equals(Line2D other)
+        {
+            return StartPoint.Equals(other.StartPoint) && EndPoint.Equals(other.EndPoint);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            return obj is Line2D && Equals((Line2D)obj);
+        }
+
+        /// <summary>
+        /// Serves as a hash function for a particular type. 
+        /// </summary>
+        /// <returns>A hash code for the current <see cref="T:System.Object"/></returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (StartPoint.GetHashCode() * 397) ^ EndPoint.GetHashCode();
+            }
+        }
+        # endregion
+    }
+}

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -111,7 +111,12 @@ namespace MathNet.Spatial.Euclidean
 
         public static Vector2D operator *(double d, Vector2D v)
         {
-            return new Vector2D(d*v.X, d*v.Y);
+            return new Vector2D(d * v.X, d * v.Y);
+        }
+
+        public static Vector2D operator *(Vector2D v, double d)
+        {
+            return d*v;
         }
 
         public static Vector2D operator /(Vector2D v, double d)
@@ -302,6 +307,11 @@ namespace MathNet.Spatial.Euclidean
             // scalar magnitude of the resulting vector.  Though the cross product is undefined in 2D space, this is 
             // a useful mathematical operation to determine direction and compute the area of 2D shapes
             return this.X*other.Y - this.Y*other.X;
+        }
+
+        public Vector2D ProjectOn(Vector2D other)
+        {
+            return other*(this.DotProduct(other)/(other.DotProduct(other)));
         }
 
         public Vector2D Normalize()

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -301,14 +301,24 @@ namespace MathNet.Spatial.Euclidean
             return (this.X*other.X) + (this.Y*other.Y);
         }
 
+        /// <summary>
+        /// Performs the 2D 'cross product' as if the 2D vectors were really 3D vectors in the z=0 plane, returning
+        /// the scalar magnitude and direction of the resulting z value.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
         public double CrossProduct(Vector2D other)
         {
-            // Perform the 2D "cross product" as if the 2D vectors were really 3D vectors on the z=0 plane, returning the 
-            // scalar magnitude of the resulting vector.  Though the cross product is undefined in 2D space, this is 
-            // a useful mathematical operation to determine direction and compute the area of 2D shapes
+            // Though the cross product is undefined in 2D space, this is a useful mathematical operation to 
+            // determine angular direction and to compute the area of 2D shapes
             return this.X*other.Y - this.Y*other.X;
         }
 
+        /// <summary>
+        /// Projects this vector onto another vector
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
         public Vector2D ProjectOn(Vector2D other)
         {
             return other*(this.DotProduct(other)/(other.DotProduct(other)));

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -296,6 +296,14 @@ namespace MathNet.Spatial.Euclidean
             return (this.X*other.X) + (this.Y*other.Y);
         }
 
+        public double CrossProduct(Vector2D other)
+        {
+            // Perform the 2D "cross product" as if the 2D vectors were really 3D vectors on the z=0 plane, returning the 
+            // scalar magnitude of the resulting vector.  Though the cross product is undefined in 2D space, this is 
+            // a useful mathematical operation to determine direction and compute the area of 2D shapes
+            return this.X*other.Y - this.Y*other.X;
+        }
+
         public Vector2D Normalize()
         {
             var l = this.Length;

--- a/src/Spatial/Spatial.csproj
+++ b/src/Spatial/Spatial.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Euclidean\Line2D.cs" />
     <Compile Include="Euclidean\Matrix2D.cs" />
     <Compile Include="Euclidean\Point2D.cs" />
     <Compile Include="Euclidean\Vector2D.cs" />

--- a/src/SpatialUnitTests/Euclidean/Line2DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Line2DTests.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using MathNet.Spatial.Euclidean;
+using NUnit.Framework;
+
+namespace MathNet.Spatial.UnitTests.Euclidean
+{
+    [TestFixture]
+    public class Line2DTests
+    {
+
+        [Test]
+        public void Constructor()
+        {
+            var p1 = new Point2D(0, 0);
+            var p2 = new Point2D(1, 1);
+            var line = new Line2D(p1, p2);
+
+            AssertGeometry.AreEqual(p1, line.StartPoint);
+            AssertGeometry.AreEqual(p2, line.EndPoint);
+        }
+
+        [Test]
+        public void ConstructorThrowsErrorOnSamePoint()
+        {
+            var p1 = new Point2D(1, -1);
+            var p2 = new Point2D(1, -1);
+            Assert.Throws<ArgumentException>(() => new Line2D(p1, p2));
+        }
+
+        [TestCase("0,0", "1,0", 1)]
+        [TestCase("0,0", "0,1", 1)]
+        [TestCase("0,0", "-1,0", 1)]
+        [TestCase("0,-1", "0,1", 2)]
+        [TestCase("-1,-1", "2,2", 4.24264068711)]
+        public void LineLength(string p1s, string p2s, double expected)
+        {
+            var p1 = Point2D.Parse(p1s);
+            var p2 = Point2D.Parse(p2s);
+            var line = new Line2D(p1, p2);
+            double len = line.Length;
+
+            Assert.AreEqual(expected, len, 1e-7);
+        }
+
+        [TestCase("0,0", "4,0", "1,0")]
+        [TestCase("3,0", "0,0", "-1,0")]
+        [TestCase("2.7,-2.7", "0,0", "-0.707106781,0.707106781")]
+        [TestCase("11,-1", "11,1", "0,1")]
+        public void LineDirection(string p1s, string p2s, string exs)
+        {
+            var p1 = Point2D.Parse(p1s);
+            var p2 = Point2D.Parse(p2s);
+            var ex = Vector2D.Parse(exs);
+            var line = new Line2D(p1, p2);
+            
+            AssertGeometry.AreEqual(ex, line.Direction);
+        }
+
+        [TestCase("0,0", "10,10", "0,0", "10,10", true)]
+        [TestCase("0,0", "10,10", "0,0", "10,11", false)]
+        public void EqualityOperator(string p1s, string p2s, string p3s, string p4s, bool expected)
+        {
+            var l1 = Line2D.Parse(p1s, p2s);
+            var l2 = Line2D.Parse(p3s, p4s);
+            
+            Assert.AreEqual(expected, l1 == l2);
+        }
+
+        [TestCase("0,0", "10,10", "0,0", "10,10", false)]
+        [TestCase("0,0", "10,10", "0,0", "10,11", true)]
+        public void InequalityOperator(string p1s, string p2s, string p3s, string p4s, bool expected)
+        {
+            var l1 = new Line2D(Point2D.Parse(p1s), Point2D.Parse(p2s));
+            var l2 = new Line2D(Point2D.Parse(p3s), Point2D.Parse(p4s));
+         
+            Assert.AreEqual(expected, l1 != l2);
+        }
+
+        [Test]
+        public void EqualityComparisonFalseAgainstNull()
+        {
+            var line = new Line2D(new Point2D(), new Point2D(1,1) );
+            Assert.IsFalse(line.Equals(null));
+        }
+
+        [Test]
+        public void AdditionOperator()
+        {
+            var l1 = Line2D.Parse("0,0", "1,1");
+            var ex = Line2D.Parse("-1,-1", "0,0");
+
+            Assert.AreEqual(ex, l1 + new Vector2D(-1, -1));
+        }
+
+        [Test]
+        public void SubtractionOperator()
+        {
+            var l1 = Line2D.Parse("0,0", "1,1");
+            var ex = Line2D.Parse("-1,-1", "0,0");
+
+            Assert.AreEqual(ex, l1 - new Vector2D(1, 1));
+        }
+
+        [TestCase("0,0", "1,-1")]   // Check start point
+        [TestCase("1,0", "1,-1")]
+        [TestCase("1,-2", "1,-1")]
+        [TestCase("4,0", "3,-1")]   // Check end point
+        [TestCase("3,0", "3,-1")]
+        [TestCase("3,-3", "3,-1")]
+        [TestCase("1.5,0", "1.5,-1")]   // Check near middle
+        [TestCase("1.5,-2", "1.5,-1")]
+        public void LineToBetweenEndPoints(string ptest, string exs)
+        {
+            var line = Line2D.Parse("1,-1", "3,-1");
+            var point = Point2D.Parse(ptest);
+            var expPoint = Point2D.Parse(exs);
+            var expLine = new Line2D(expPoint, point);
+
+            Assert.AreEqual(expLine, line.LineTo(point, true));
+        }
+
+        [TestCase("0,0", "0,-1")]   // Check start point
+        [TestCase("1,0", "1,-1")]
+        [TestCase("1,-2", "1,-1")]
+        [TestCase("4,0", "4,-1")]   // Check end point
+        [TestCase("3,0", "3,-1")]
+        [TestCase("3,-3", "3,-1")]
+        [TestCase("1.5,0", "1.5,-1")]   // Check near middle
+        [TestCase("1.5,-2", "1.5,-1")]
+        public void LineToIgnoreEndPoints(string ptest, string exs)
+        {
+            var line = Line2D.Parse("1,-1", "3,-1");
+            var point = Point2D.Parse(ptest);
+            var expPoint = Point2D.Parse(exs);
+            var expLine = new Line2D(expPoint, point);
+
+            Assert.AreEqual(expLine, line.LineTo(point, false));
+        }
+
+        [Test]
+        public void ToStringCheck()
+        {
+            string check = Line2D.Parse("0,0", "1,1").ToString();
+
+            Assert.AreEqual("StartPoint: (0, 0), EndPoint: (1, 1)", check);
+        }
+    }
+}

--- a/src/SpatialUnitTests/Euclidean/Vector2DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Vector2DTests.cs
@@ -127,6 +127,22 @@ namespace MathNet.Spatial.UnitTests.Euclidean
             }
         }
 
+        [TestCase("-1, -2", 2, "-2, -4")]
+        public void FlippedMultiplyAndScaleBy(string vs, double d, string evs)
+        {
+            var v = Vector2D.Parse(vs);
+            var actuals = new[]
+                          {
+                              v * d,
+                              v.ScaleBy(d)
+                          };
+            var expected = Vector2D.Parse(evs);
+            foreach (var actual in actuals)
+            {
+                Assert.AreEqual(expected, actual);
+            }
+        }
+
         [TestCase("-1, -2", 2, "-0.5, -1")]
         public void Divide(string vs, double d, string evs)
         {
@@ -306,5 +322,90 @@ namespace MathNet.Spatial.UnitTests.Euclidean
                 AssertGeometry.AreEqual(v, roundTrip);
             }
         }
+
+        [Test]
+        public void PolarConstructorThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => { new Vector2D(-1.0, new Angle(0, new Radians())); });
+        }
+
+        [Test]
+        public void CheckCachedXAxis()
+        {
+            AssertGeometry.AreEqual(new Vector2D(1, 0), Vector2D.XAxis);
+        }
+
+        [Test]
+        public void CheckCachedYAxis()
+        {
+            AssertGeometry.AreEqual(new Vector2D(0, 1), Vector2D.YAxis);
+        }
+
+        [Test]
+        public void EqualityComparerThrowsExceptionOnNegativeTolerance()
+        {
+            var v1 = new Vector2D(0, 0);
+            var v2 = new Vector2D(1, 1);
+            Assert.Throws<ArgumentException>(() => v1.Equals(v2, -0.01));
+        }
+
+        [Test]
+        public void EqualityComparerReturnsFalseOnNullReference()
+        {
+            Assert.IsFalse((new Vector2D()).Equals(null));
+        }
+
+
+        [TestCase("1,0", "0,1", "90°")]
+        [TestCase("0,1", "1,0", "90°", "90°")]
+        [TestCase("-0.99985, 0.01745", "-1, 0", "1°")]
+        [TestCase("-0.99985, -0.01745", "-1, 0", "1°")]
+        [TestCase("0.99985, 0.01745", "1, 0","1°")]
+        [TestCase("0.99985, -0.01745", "1, 0", "1°")]
+        public void UnSignedAngleTo(string v1s, string v2s, string expectedAngle)
+        {
+            var v1 = Vector2D.Parse(v1s);
+            var v2 = Vector2D.Parse(v2s);
+            var expected = Angle.Parse(expectedAngle);
+
+            var angle = v1.AngleTo(v2);
+
+            Assert.AreEqual(expected.Degrees, angle.Degrees, 1e-3);
+        }
+
+        [TestCase("1,0", "0,1", 1)]
+        [TestCase("-1,0", "0,1", -1)]
+        [TestCase("0.5003,-0.7066", "0.0739,0.7981", 0.452)]
+        [TestCase("0.7097,0.6059", "0.0142,-0.7630", -0.550)]
+        [TestCase("-0.6864,0.7036", "-0.8541,-0.1124", 0.678)]
+        [TestCase("-0.2738,0.6783", "0.1695,0.9110", -0.364)]
+        public void CrossProducts(string v1s, string v2s, double expected)
+        {
+            // Generated test data from http://calculator.tutorvista.com/math/8/cross-product-calculator.html
+            var v1 = Vector2D.Parse(v1s);
+            var v2 = Vector2D.Parse(v2s);
+
+            double cross = v1.CrossProduct(v2);
+
+            Assert.AreEqual(expected, cross, 1e-3);
+        }
+
+        [TestCase("1,0", "2,0", "1,0")]
+        [TestCase("1,1", "2,0", "1,0")]
+        [TestCase("1,0", "-2,0", "1,0")]
+        [TestCase("-1,1", "2,0", "-1,0")]
+        [TestCase("-0.0563,-0.2904", "-0.3671,-0.7945", "-0.120,-0.261")]
+        [TestCase("0.4610,0.9067", "-0.7948,-0.7748", "0.690,0.672")]
+        [TestCase("0.3916,-0.9644", "-0.0873,0.0978", "0.653,-0.731")]
+        public void VectorProjection(string v1s, string v2s, string exs)
+        {
+            var v1 = Vector2D.Parse(v1s);
+            var v2 = Vector2D.Parse(v2s);
+            var ex = Vector2D.Parse(exs);
+
+            AssertGeometry.AreEqual(ex, v1.ProjectOn(v2), 1e-3);
+        }
+
+
     }
 }

--- a/src/SpatialUnitTests/SpatialUnitTests.csproj
+++ b/src/SpatialUnitTests/SpatialUnitTests.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Euclidean\Line2DTests.cs" />
     <Compile Include="Euclidean\Point2DTests.cs" />
     <Compile Include="Euclidean\Vector2DTests.cs" />
     <Compile Include="Euclidean\CoordinateSystemTest.cs" />


### PR DESCRIPTION
I added the following two methods to the Vector2D struct:

* CrossProduct - performs the commonly used 2d 'cross product' equivalent, which returns a positive or negative scalar that would be the z component of the 3D cross product if both vectors were 3D vectors in the z=0 plane

* ProjectOn - projects one vector onto another vector, following the style of Vector3D.ProjectOn

Additionally I added unit tests to cover those methods and a few others, bringing the test coverage up to 85% by branch, 88% by lines of code.

I also added a Line2D struct which follows the example of Line3D, and unit tests to cover all of the math portions (83% by branch, 93% by lines of code)

