### PR TITLE
Fix the check for collinear points in Plane constructor

### DIFF
--- a/src/Spatial/Euclidean/Plane.cs
+++ b/src/Spatial/Euclidean/Plane.cs
@@ -54,12 +54,14 @@ namespace MathNet.Spatial.Euclidean
             }
             Vector3D v1 = new Vector3D(p2.X - p1.X, p2.Y - p1.Y, p2.Z - p1.Z);
             Vector3D v2 = new Vector3D(p3.X - p1.X, p3.Y - p1.Y, p3.Z - p1.Z);
-            if (v1.Normalize().Equals(v2.Normalize()))
+            Vector3D cross = v1.CrossProduct(v2);
+
+            if (cross.Length <= float.Epsilon)
             {
-                throw new ArgumentException("the 3 points should not be in the same line");
+                throw new ArgumentException("The 3 points should not be on the same line");
             }
             this.RootPoint = p1;
-            this.Normal = v1.CrossProduct(v2).Normalize();
+            this.Normal = cross.Normalize();
             this.D = -this.RootPoint.ToVector3D().DotProduct(this.Normal);
         }
 


### PR DESCRIPTION
Currently, if 3 points are passed to the Plane constructor and the first point is between the other two, the col-linear check in the constructor fails (UnitVector3D class will instead throw the exception). An example is provided below:

Point3D p1 = new Point3D(0, 0, 0);
Point3D p2 = new Point3D(1, 0, 0);
Point3D p3 = new Point3D(2, 0, 0);
Plane p = new Plane(p2, p1, p3);

My fix is based on the magnitude of the cross product of the vectors formed by the 3 points.