### PR TITLE
changed degree symbol character

### DIFF
--- a/src/Spatial/Units/Degrees.cs
+++ b/src/Spatial/Units/Degrees.cs
@@ -7,7 +7,7 @@ namespace MathNet.Spatial.Units
     public struct Degrees : IAngleUnit
     {
         private const double Conv = Math.PI / 180.0;
-        internal const string Name = "°";
+        internal const string Name = "\u00B0";
 
         public double Conversionfactor
         {

--- a/src/Spatial/Units/Degrees.cs
+++ b/src/Spatial/Units/Degrees.cs
@@ -7,7 +7,7 @@ namespace MathNet.Spatial.Units
     public struct Degrees : IAngleUnit
     {
         private const double Conv = Math.PI / 180.0;
-        internal const string Name = "°";
+        internal const string Name = "Â°";
 
         public double Conversionfactor
         {


### PR DESCRIPTION
##### An error occurred while loading `Degrees.cs` file in Visual Studio

###### Problem
The `Name` field of `Degrees` struct has degree symbol value `°`. It looks good only with Windows 1252 encoding, A problem is Visual Studio on not-western language Windows could not detect right encoding for the file. Visual Studio knows the file is not just ASCII file, so try to detect an encoding automatically and fail. Because Windows 1252 is not in encoding candidates on non-western language Windows.

###### Fix
Changed current degree symbol to the unicode's one(http://unicode-table.com/en/00B0/) and saved the file `Degrees.cs` as UTF-8. Almost editors detect unicode encodings very well than old and non-universal encodings like Windows 1252 :)