### PR TITLE
Issue32

### DIFF
--- a/src/Spatial/Euclidean/Line2D.cs
+++ b/src/Spatial/Euclidean/Line2D.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using MathNet.Spatial.Units;
 
 namespace MathNet.Spatial.Euclidean
 {
@@ -118,9 +119,12 @@ namespace MathNet.Spatial.Euclidean
         /// Compute the intersection between two lines
         /// </summary>
         /// <param name="other">The other line to compute the intersection with</param>
-        /// <returns>The point at the intersection of two lines, or null if the lines are parallelnu.</returns>
+        /// <returns>The point at the intersection of two lines, or null if the lines are parallel.</returns>
         public Point2D? IntersectWith(Line2D other)
         {
+            if (this.IsParallelTo(other))
+                return null;
+
             // http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
             Point2D p = this.StartPoint;
             Point2D q = other.StartPoint;
@@ -129,11 +133,31 @@ namespace MathNet.Spatial.Euclidean
 
             double t = (q - p).CrossProduct(s) / (r.CrossProduct(s));
 
-            if (double.IsPositiveInfinity(t) || double.IsNegativeInfinity(t))
-                return null;
-
             return p + t * r;
         }
+
+        /// <summary>
+        /// Checks to determine whether or not two lines are parallel to each other, using the cross product within 
+        /// the epsilon for the double floating point value.
+        /// </summary>
+        /// <param name="other">The other line to check this one against</param>
+        /// <returns>True if the lines are parallel, false if they are not</returns>
+        public bool IsParallelTo(Line2D other)
+        {
+            return Math.Abs(this.Direction.CrossProduct(other.Direction)) < double.Epsilon;
+        }
+
+        /// <summary>
+        /// Checks to determine whether or not two lines are parallel to each other within a specified angle tolerance
+        /// </summary>
+        /// <param name="other">The other line to check this one against</param>
+        /// <param name="angleTolerance">If the angle between line directions is less than this value, the method returns true</param>
+        /// <returns>True if the lines are parallel within the angle tolerance, false if they are not</returns>
+        public bool IsParallelTo(Line2D other, Angle angleTolerance)
+        {
+            return this.Direction.AngleTo(other.Direction) <= angleTolerance;
+        }
+
 
         # region Operators 
 

--- a/src/Spatial/Euclidean/Line3D.cs
+++ b/src/Spatial/Euclidean/Line3D.cs
@@ -3,6 +3,8 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using MathNet.Numerics;
+using MathNet.Spatial.Units;
 
 namespace MathNet.Spatial.Euclidean
 {
@@ -154,6 +156,28 @@ namespace MathNet.Spatial.Euclidean
         public Point3D? IntersectionWith(Plane plane, double tolerance = double.Epsilon)
         {
             return plane.IntersectionWith(this, tolerance);
+        }
+
+        /// <summary>
+        /// Checks to determine whether or not two lines are parallel to each other, using the dot product within 
+        /// the double precision specified in the MathNet.Numerics package.
+        /// </summary>
+        /// <param name="other">The other line to check this one against</param>
+        /// <returns>True if the lines are parallel, false if they are not</returns>
+        public bool IsParallelTo(Line3D other)
+        {
+            return this.Direction.IsParallelTo(other.Direction, Precision.DoublePrecision * 2);
+        }
+
+        /// <summary>
+        /// Checks to determine whether or not two lines are parallel to each other within a specified angle tolerance
+        /// </summary>
+        /// <param name="other">The other line to check this one against</param>
+        /// <param name="angleTolerance">If the angle between line directions is less than this value, the method returns true</param>
+        /// <returns>True if the lines are parallel within the angle tolerance, false if they are not</returns>
+        public bool IsParallelTo(Line3D other, Angle angleTolerance)
+        {
+            return this.Direction.IsParallelTo(other.Direction, angleTolerance);
         }
 
         /// <summary>

--- a/src/Spatial/Euclidean/UnitVector3D.cs
+++ b/src/Spatial/Euclidean/UnitVector3D.cs
@@ -369,7 +369,7 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="tolerance">A tolerance value for the dot product method.  Values below 2*Precision.DoublePrecision may cause issues.</param>
         /// <returns>True if the vector dot product is within the given double tolerance of unity, false if not</returns>
         [Pure]
-        public bool IsParallelTo(Vector3D othervector, double tolerance = 1e-6)
+        public bool IsParallelTo(Vector3D othervector, double tolerance = 1e-10)
         {
             var other = othervector.Normalize();
             return IsParallelTo(other, tolerance);
@@ -383,7 +383,7 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="tolerance">A tolerance value for the dot product method.  Values below 2*Precision.DoublePrecision may cause issues.</param>
         /// <returns>True if the vector dot product is within the given double tolerance of unity, false if not</returns>
         [Pure]
-        public bool IsParallelTo(UnitVector3D othervector, double tolerance = 1e-6)
+        public bool IsParallelTo(UnitVector3D othervector, double tolerance = 1e-10)
         {
             // This is the master method for all Vector3D and UnitVector3D IsParallelTo comparisons.  Everything else 
             // ends up here sooner or later.
@@ -424,14 +424,14 @@ namespace MathNet.Spatial.Euclidean
         }
 
         [Pure]
-        public bool IsPerpendicularTo(Vector3D othervector, double tolerance = 1e-6)
+        public bool IsPerpendicularTo(Vector3D othervector, double tolerance = 1e-10)
         {
             var other = othervector.Normalize();
             return Math.Abs(this.DotProduct(other)) < tolerance;
         }
 
         [Pure]
-        public bool IsPerpendicularTo(UnitVector3D othervector, double tolerance = 1e-6)
+        public bool IsPerpendicularTo(UnitVector3D othervector, double tolerance = 1e-10)
         {
             return Math.Abs(this.DotProduct(othervector)) < tolerance;
         }

--- a/src/Spatial/Euclidean/UnitVector3D.cs
+++ b/src/Spatial/Euclidean/UnitVector3D.cs
@@ -361,19 +361,66 @@ namespace MathNet.Spatial.Euclidean
             return pd*this;
         }
 
+        /// <summary>
+        /// Computes whether or not this unit vector is parallel to another vector using the dot product method and comparing it
+        /// to within a specified tolerance.
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="tolerance">A tolerance value for the dot product method.  Values below 2*Precision.DoublePrecision may cause issues.</param>
+        /// <returns>True if the vector dot product is within the given double tolerance of unity, false if not</returns>
         [Pure]
         public bool IsParallelTo(Vector3D othervector, double tolerance = 1e-6)
         {
             var other = othervector.Normalize();
-            var dp = Math.Abs(this.DotProduct(other));
-            return Math.Abs(1 - dp) < tolerance;
+            return IsParallelTo(other, tolerance);
         }
 
+        /// <summary>
+        /// Computes whether or not this unit vector is parallel to a unit vector using the dot product method and comparing it
+        /// to within a specified tolerance.
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="tolerance">A tolerance value for the dot product method.  Values below 2*Precision.DoublePrecision may cause issues.</param>
+        /// <returns>True if the vector dot product is within the given double tolerance of unity, false if not</returns>
         [Pure]
         public bool IsParallelTo(UnitVector3D othervector, double tolerance = 1e-6)
         {
+            // This is the master method for all Vector3D and UnitVector3D IsParallelTo comparisons.  Everything else 
+            // ends up here sooner or later.
             var dp = Math.Abs(this.DotProduct(othervector));
-            return Math.Abs(1 - dp) < tolerance;
+            return Math.Abs(1 - dp) <= tolerance;
+        }
+
+        /// <summary>
+        /// Determine whether or not this unit vector is parallel to another unit vector within a given angle tolerance.
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="angleTolerance"></param>
+        /// <returns>true if the vectors are parallel within the angle tolerance, false if they are not</returns>
+        [Pure]
+        public bool IsParallelTo(UnitVector3D othervector, Angle angleTolerance)
+        {
+            // Compute the angle between these vectors 
+            var angle = this.AngleTo(othervector);
+
+            // Compute the 180° opposite of the angle
+            var opposite = Angle.FromDegrees(180) - angle;
+
+            // Check against the smaller of the two
+            return ((angle < opposite) ? angle : opposite) < angleTolerance;
+        }
+
+        /// <summary>
+        /// Determine whether or not this unit vector is parallel to a vector within a given angle tolerance.
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="angleTolerance"></param>
+        /// <returns>true if the vectors are parallel within the angle tolerance, false if they are not</returns>
+        [Pure]
+        public bool IsParallelTo(Vector3D othervector, Angle angleTolerance)
+        {
+            var other = othervector.Normalize();
+            return IsParallelTo(other, angleTolerance);
         }
 
         [Pure]

--- a/src/Spatial/Euclidean/UnitVector3D.cs
+++ b/src/Spatial/Euclidean/UnitVector3D.cs
@@ -506,10 +506,10 @@ namespace MathNet.Spatial.Euclidean
         }
 
         /// <summary>
-        /// The nearest angle between the vectors
+        /// Compute the angle between this vector and a unit vector using the arccosine of the dot product.
         /// </summary>
         /// <param name="v">The other vector</param>
-        /// <returns>The angle</returns>
+        /// <returns>The angle between the vectors, with a range between 0° and 180°</returns>
         public Angle AngleTo(UnitVector3D v)
         {
             var dp = this.DotProduct(v);

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -227,7 +227,7 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="othervector"></param>
         /// <param name="tolerance"></param>
         /// <returns>True if the vector dot product is within the given double tolerance of unity, false if not</returns>
-        public bool IsParallelTo(Vector2D othervector, double tolerance = 1e-6)
+        public bool IsParallelTo(Vector2D othervector, double tolerance = 1e-10)
         {
             var @this = this.Normalize();
             var other = othervector.Normalize();
@@ -253,7 +253,7 @@ namespace MathNet.Spatial.Euclidean
             return ((angle < opposite) ? angle : opposite) < angleTolerance;
         }
 
-        public bool IsPerpendicularTo(Vector2D othervector, double tolerance = 1e-6)
+        public bool IsPerpendicularTo(Vector2D othervector, double tolerance = 1e-10)
         {
             var @this = this.Normalize();
             var other = othervector.Normalize();

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -227,7 +227,7 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="othervector"></param>
         /// <param name="tolerance"></param>
         /// <returns>True if the vector dot product is within the given double tolerance of unity, false if not</returns>
-        public bool IsParallelTo(Vector2D othervector, double tolerance = 1.40129846432482E-45)
+        public bool IsParallelTo(Vector2D othervector, double tolerance = 1e-6)
         {
             var @this = this.Normalize();
             var other = othervector.Normalize();
@@ -253,7 +253,7 @@ namespace MathNet.Spatial.Euclidean
             return ((angle < opposite) ? angle : opposite) < angleTolerance;
         }
 
-        public bool IsPerpendicularTo(Vector2D othervector, double tolerance = 1.40129846432482E-45)
+        public bool IsPerpendicularTo(Vector2D othervector, double tolerance = 1e-6)
         {
             var @this = this.Normalize();
             var other = othervector.Normalize();

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -6,6 +6,7 @@ using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Xml.Serialization;
+using MathNet.Numerics.Financial;
 using MathNet.Numerics.LinearAlgebra;
 using MathNet.Spatial.Units;
 
@@ -219,12 +220,37 @@ namespace MathNet.Spatial.Euclidean
             writer.WriteAttribute("Y", this.Y);
         }
 
+        /// <summary>
+        /// Computes whether or not this vector is parallel to another vector using the dot product method
+        /// and comparing to within a specified tolerance
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="tolerance"></param>
+        /// <returns>True if the vector dot product is within the given double tolerance of unity, false if not</returns>
         public bool IsParallelTo(Vector2D othervector, double tolerance = 1.40129846432482E-45)
         {
             var @this = this.Normalize();
             var other = othervector.Normalize();
             var dp = Math.Abs(@this.DotProduct(other));
-            return Math.Abs(1 - dp) < tolerance;
+            return Math.Abs(1 - dp) <= tolerance;
+        }
+
+        /// <summary>
+        /// Computes whether or not this vector is parallel to another vector within a given angle tolerance.
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="angleTolerance"></param>
+        /// <returns>True if the vectors are parallel within the angle tolerance, false if they are not</returns>
+        public bool IsParallelTo(Vector2D othervector, Angle angleTolerance)
+        {
+            // Compute the angle between these vectors 
+            var angle = this.AngleTo(othervector);
+
+            // Compute the 180° opposite of the angle
+            var opposite = Angle.FromDegrees(180) - angle;
+
+            // Check against the smaller of the two
+            return ((angle < opposite) ? angle : opposite) < angleTolerance;
         }
 
         public bool IsPerpendicularTo(Vector2D othervector, double tolerance = 1.40129846432482E-45)
@@ -270,6 +296,11 @@ namespace MathNet.Spatial.Euclidean
             return new Angle(a, AngleUnit.Radians);
         }
 
+        /// <summary>
+        /// Compute the angle between this vector and another using the arccosine of the dot product.
+        /// </summary>
+        /// <param name="toVector2D"></param>
+        /// <returns>The angle between vectors, with a range between 0° and 180°</returns>
         public Angle AngleTo(Vector2D toVector2D)
         {
             var @this = this.Normalize();

--- a/src/Spatial/Euclidean/Vector3D.cs
+++ b/src/Spatial/Euclidean/Vector3D.cs
@@ -311,6 +311,13 @@ namespace MathNet.Spatial.Euclidean
             return pd*uv;
         }
 
+        /// <summary>
+        /// Computes whether or not this vector is parallel to another vector using the dot product method and comparing it
+        /// to within a specified tolerance.
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="tolerance"></param>
+        /// <returns>true if the vector dot product is within the given tolerance of unity, false if it is not</returns>
         public bool IsParallelTo(Vector3D othervector, double tolerance = 1e-6)
         {
             var @this = this.Normalize();
@@ -319,6 +326,13 @@ namespace MathNet.Spatial.Euclidean
             return Math.Abs(1 - dp) < tolerance;
         }
 
+        /// <summary>
+        /// Computes whether or not this vector is parallel to a unit vector using the dot product method and comparing it
+        /// to within a specified tolerance.
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="tolerance"></param>
+        /// <returns>true if the vector dot product is within the given tolerance of unity, false if not</returns>
         public bool IsParallelTo(UnitVector3D othervector, double tolerance = 1e-6)
         {
             var @this = this.Normalize();
@@ -326,6 +340,31 @@ namespace MathNet.Spatial.Euclidean
             return Math.Abs(1 - dp) < tolerance;
         }
 
+        /// <summary>
+        /// Determine whether or not this vector is parallel to another vector within a given angle tolerance.
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="angleTolerance"></param>
+        /// <returns>true if the vectors are parallel within the angle tolerance, false if they are not</returns>
+        public bool IsParallelTo(Vector3D othervector, Angle angleTolerance)
+        {
+            // Compute the angle between these vectors 
+            var angle = this.AngleTo(othervector);
+
+            // Compute the 180° opposite of the angle
+            var opposite = Angle.FromDegrees(180) - angle;
+
+            // Check against the smaller of the two
+            return ((angle < opposite) ? angle : opposite) < angleTolerance;
+        }
+
+        /// <summary>
+        /// Computes whether or not this vector is perpendicular to another vector using the dot product method and
+        /// comparing it to within a specified tolerance
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="tolerance"></param>
+        /// <returns>true if the vector dot product is within the given tolerance of zero, false if not</returns>
         public bool IsPerpendicularTo(Vector3D othervector, double tolerance = 1e-6)
         {
             var @this = this.Normalize();
@@ -333,12 +372,23 @@ namespace MathNet.Spatial.Euclidean
             return Math.Abs(@this.DotProduct(other)) < tolerance;
         }
 
+        /// <summary>
+        /// Computes whether or not this vector is perpendicular to another vector using the dot product method and
+        /// comparing it to within a specified tolerance
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="tolerance"></param>
+        /// <returns>true if the vector dot product is within the given tolerance of zero, false if not</returns>
         public bool IsPerpendicularTo(UnitVector3D othervector, double tolerance = 1e-6)
         {
             var @this = this.Normalize();
             return Math.Abs(@this.DotProduct(othervector)) < tolerance;
         }
 
+        /// <summary>
+        /// Inverses the direction of the vector, equivalent to multiplying by -1
+        /// </summary>
+        /// <returns></returns>
         public Vector3D Negate()
         {
             return new Vector3D(-1*this.X, -1*this.Y, -1*this.Z);
@@ -414,10 +464,10 @@ namespace MathNet.Spatial.Euclidean
         }
 
         /// <summary>
-        /// The nearest angle between the vectors
+        /// Compute the angle between this vector and another using the arccosine of the dot product.
         /// </summary>
         /// <param name="v">The other vector</param>
-        /// <returns>The angle</returns>
+        /// <returns>The angle between the vectors, with a range between 0° and 180°</returns>
         public Angle AngleTo(Vector3D v)
         {
             var uv1 = this.Normalize();
@@ -426,10 +476,10 @@ namespace MathNet.Spatial.Euclidean
         }
 
         /// <summary>
-        /// The nearest angle between the vectors
+        /// Compute the angle between this vector and a unit vector using the arccosine of the dot product.
         /// </summary>
         /// <param name="v">The other vector</param>
-        /// <returns>The angle</returns>
+        /// <returns>The angle between the vectors, with a range between 0° and 180°</returns>
         public Angle AngleTo(UnitVector3D v)
         {
             var uv = this.Normalize();

--- a/src/Spatial/Euclidean/Vector3D.cs
+++ b/src/Spatial/Euclidean/Vector3D.cs
@@ -290,6 +290,10 @@ namespace MathNet.Spatial.Euclidean
         ////    return new System.Windows.Media.Media3D.Vector3D(p.X, p.Y, p.Z);
         ////}
 
+        /// <summary>
+        /// Compute and return a unit vector from this vector
+        /// </summary>
+        /// <returns></returns>
         public UnitVector3D Normalize()
         {
             return new UnitVector3D(this.X, this.Y, this.Z);
@@ -316,14 +320,12 @@ namespace MathNet.Spatial.Euclidean
         /// to within a specified tolerance.
         /// </summary>
         /// <param name="othervector"></param>
-        /// <param name="tolerance"></param>
+        /// <param name="tolerance">A tolerance value for the dot product method.  Values below 2*Precision.DoublePrecision may cause issues.</param>
         /// <returns>true if the vector dot product is within the given tolerance of unity, false if it is not</returns>
         public bool IsParallelTo(Vector3D othervector, double tolerance = 1e-6)
         {
             var @this = this.Normalize();
-            var other = othervector.Normalize();
-            var dp = Math.Abs(@this.DotProduct(other));
-            return Math.Abs(1 - dp) < tolerance;
+            return @this.IsParallelTo(othervector, tolerance);
         }
 
         /// <summary>
@@ -331,13 +333,12 @@ namespace MathNet.Spatial.Euclidean
         /// to within a specified tolerance.
         /// </summary>
         /// <param name="othervector"></param>
-        /// <param name="tolerance"></param>
+        /// <param name="tolerance">A tolerance value for the dot product method.  Values below 2*Precision.DoublePrecision may cause issues.</param>
         /// <returns>true if the vector dot product is within the given tolerance of unity, false if not</returns>
         public bool IsParallelTo(UnitVector3D othervector, double tolerance = 1e-6)
         {
             var @this = this.Normalize();
-            var dp = Math.Abs(@this.DotProduct(othervector));
-            return Math.Abs(1 - dp) < tolerance;
+            return @this.IsParallelTo(othervector, tolerance);
         }
 
         /// <summary>

--- a/src/Spatial/Euclidean/Vector3D.cs
+++ b/src/Spatial/Euclidean/Vector3D.cs
@@ -322,7 +322,7 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="othervector"></param>
         /// <param name="tolerance">A tolerance value for the dot product method.  Values below 2*Precision.DoublePrecision may cause issues.</param>
         /// <returns>true if the vector dot product is within the given tolerance of unity, false if it is not</returns>
-        public bool IsParallelTo(Vector3D othervector, double tolerance = 1e-6)
+        public bool IsParallelTo(Vector3D othervector, double tolerance = 1e-10)
         {
             var @this = this.Normalize();
             return @this.IsParallelTo(othervector, tolerance);
@@ -335,7 +335,7 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="othervector"></param>
         /// <param name="tolerance">A tolerance value for the dot product method.  Values below 2*Precision.DoublePrecision may cause issues.</param>
         /// <returns>true if the vector dot product is within the given tolerance of unity, false if not</returns>
-        public bool IsParallelTo(UnitVector3D othervector, double tolerance = 1e-6)
+        public bool IsParallelTo(UnitVector3D othervector, double tolerance = 1e-10)
         {
             var @this = this.Normalize();
             return @this.IsParallelTo(othervector, tolerance);
@@ -349,14 +349,20 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>true if the vectors are parallel within the angle tolerance, false if they are not</returns>
         public bool IsParallelTo(Vector3D othervector, Angle angleTolerance)
         {
-            // Compute the angle between these vectors 
-            var angle = this.AngleTo(othervector);
+            var @this = this.Normalize();
+            return @this.IsParallelTo(othervector, angleTolerance);
+        }
 
-            // Compute the 180° opposite of the angle
-            var opposite = Angle.FromDegrees(180) - angle;
-
-            // Check against the smaller of the two
-            return ((angle < opposite) ? angle : opposite) < angleTolerance;
+        /// <summary>
+        /// Determine whether or not this vector is parallel to a unit vector within a given angle tolerance.
+        /// </summary>
+        /// <param name="othervector"></param>
+        /// <param name="angleTolerance"></param>
+        /// <returns>true if the vectors are parallel within the angle tolerance, false if they are not</returns>
+        public bool IsParallelTo(UnitVector3D othervector, Angle angleTolerance)
+        {
+            var @this = this.Normalize();
+            return @this.IsParallelTo(othervector, angleTolerance);
         }
 
         /// <summary>

--- a/src/SpatialUnitTests/Euclidean/Line2DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Line2DTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using MathNet.Spatial.Euclidean;
+using MathNet.Spatial.Units;
 using NUnit.Framework;
 
 namespace MathNet.Spatial.UnitTests.Euclidean
@@ -174,8 +175,35 @@ namespace MathNet.Spatial.UnitTests.Euclidean
             var line1 = Line2D.Parse(s1, e1);
             var line2 = Line2D.Parse(s2, e2);
             Point2D? e = string.IsNullOrEmpty(expected) ? (Point2D?)null : Point2D.Parse(expected);
+            Point2D? intersection = line1.IntersectWith(line2);
 
-            Assert.AreEqual(e, line1.IntersectWith(line2));
+            Assert.AreEqual(e, intersection);
+        }
+
+
+        [TestCase("0,0", "0,1", "1,1", "1,2", true)]
+        [TestCase("0,0", "0,-1", "1,1", "1,2", true)]
+        [TestCase("0,0", "0.5,-1", "1,1", "1,2", false)]
+        [TestCase("0,0", "0.00001,-1.0000", "1,1", "1,2", false)]
+        public void IsParallelToWithinDoubleTol(string s1, string e1, string s2, string e2, bool expected)
+        {
+            var line1 = Line2D.Parse(s1, e1);
+            var line2 = Line2D.Parse(s2, e2);
+            
+            Assert.AreEqual(expected, line1.IsParallelTo(line2));
+        }
+
+        [TestCase("0,0", "0,1", "1,1", "1,2", 0.01, true)]
+        [TestCase("0,0", "0,-1", "1,1", "1,2", 0.01, true)]
+        [TestCase("0,0", "0.5,-1", "1,1", "1,2", 0.01, false)]
+        [TestCase("0,0", "0.001,-1.0000", "1,1", "1,2", 0.05, false)]
+        [TestCase("0,0", "0.001,-1.0000", "1,1", "1,2", 0.06, true)]
+        public void IsParallelToWithinAngleTol(string s1, string e1, string s2, string e2, double degreesTol, bool expected)
+        {
+            var line1 = Line2D.Parse(s1, e1);
+            var line2 = Line2D.Parse(s2, e2);
+
+            Assert.AreEqual(expected, line1.IsParallelTo(line2, Angle.FromDegrees(degreesTol)));
         }
 
         [Test]

--- a/src/SpatialUnitTests/Euclidean/Line3DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Line3DTests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using MathNet.Spatial.Euclidean;
+using MathNet.Spatial.Units;
 using NUnit.Framework;
 
 namespace MathNet.Spatial.UnitTests.Euclidean
@@ -122,6 +123,31 @@ namespace MathNet.Spatial.UnitTests.Euclidean
                 var roundTrip = (Line3D)formatter.Deserialize(ms);
                 AssertGeometry.AreEqual(line, roundTrip);
             }
+        }
+
+        [TestCase("0,0,0", "0,0,1", "0,1,1", "0,1,2", true)]
+        [TestCase("0,0,0", "0,0,-1", "0,1,1", "0,1,2", true)]
+        [TestCase("0,0,0", "0,0.5,-1", "0,1,1", "0,1,2", false)]
+        [TestCase("0,0,0", "0,0.00001,-1.0000", "0,1,1", "0,1,2", false)]
+        public void IsParallelToWithinDoubleTol(string s1, string e1, string s2, string e2, bool expected)
+        {
+            var line1 = Line3D.Parse(s1, e1);
+            var line2 = Line3D.Parse(s2, e2);
+
+            Assert.AreEqual(expected, line1.IsParallelTo(line2));
+        }
+
+        [TestCase("0,0,0", "0,0,1", "0,1,1", "0,1,2", 0.01, true)]
+        [TestCase("0,0,0", "0,0,-1", "0,1,1", "0,1,2", 0.01, true)]
+        [TestCase("0,0,0", "0,0.5,-1", "0,1,1", "0,1,2", 0.01, false)]
+        [TestCase("0,0,0", "0,0.001,-1.0000", "0,1,1", "0,1,2", 0.05, false)]
+        [TestCase("0,0,0", "0,0.001,-1.0000", "0,1,1", "0,1,2", 0.06, true)]
+        public void IsParallelToWithinAngleTol(string s1, string e1, string s2, string e2, double degreesTol, bool expected)
+        {
+            var line1 = Line3D.Parse(s1, e1);
+            var line2 = Line3D.Parse(s2, e2);
+
+            Assert.AreEqual(expected, line1.IsParallelTo(line2, Angle.FromDegrees(degreesTol)));
         }
     }
 }

--- a/src/SpatialUnitTests/Euclidean/Vector2DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Vector2DTests.cs
@@ -199,12 +199,36 @@ namespace MathNet.Spatial.UnitTests.Euclidean
         [TestCase("1, 0", "1, 1", 1e-4, false)]
         [TestCase("1, 1", "1, 1", 1e-4, true)]
         [TestCase("1, -1", "-1, 1", 1e-4, true)]
-        public void IsParallelTo(string v1s, string v2s, double tol, bool expected)
+        [TestCase("1, 0.5", "-1, -0.5", 1e-4, true)]
+        [TestCase("1, 0.5", "-1, 0.5000000005", 1e-4, false)]
+        public void IsParallelToByDoubleTolerance(string v1s, string v2s, double tol, bool expected)
         {
             var v1 = Vector2D.Parse(v1s);
             var v2 = Vector2D.Parse(v2s);
             Assert.AreEqual(expected, v1.IsParallelTo(v2, tol));
             Assert.AreEqual(expected, v2.IsParallelTo(v1, tol));
+        }
+
+        [TestCase("1, 0", "1, 0", 1e-4, true)]
+        [TestCase("1, 0", "-1, 0", 1e-4, true)]
+        [TestCase("1, 0", "1, 1", 1e-4, false)]
+        [TestCase("1, 1", "1, 1", 1e-4, true)]
+        [TestCase("1, -1", "-1, 1", 1e-4, true)]
+        [TestCase("1, 0", "1, 0.001", 0.06, true)]
+        [TestCase("1, 0", "1, -0.001", 0.06, true)]
+        [TestCase("-1, 0", "1, 0.001", 0.06, true)]
+        [TestCase("-1, 0", "1, -0.001", 0.06, true)]
+        [TestCase("1, 0", "1, 0.001", 0.05, false)]
+        [TestCase("1, 0", "1, -0.001", 0.05, false)]
+        [TestCase("-1, 0", "1, 0.001", 0.05, false)]
+        [TestCase("-1, 0", "1, -0.001", 0.05, false)]
+        [TestCase("1, 0.5", "-1, -0.5", 1e-4, true)]
+        public void IsParallelToByAngleTolerance(string v1s, string v2s, double degreesTolerance, bool expected)
+        {
+            var v1 = Vector2D.Parse(v1s);
+            var v2 = Vector2D.Parse(v2s);
+            Assert.AreEqual(expected, v1.IsParallelTo(v2, Angle.FromDegrees(degreesTolerance)));
+            Assert.AreEqual(expected, v2.IsParallelTo(v1, Angle.FromDegrees(degreesTolerance)));
         }
 
         [TestCase("1, 0", "0, 1", false, 90)]
@@ -215,7 +239,7 @@ namespace MathNet.Spatial.UnitTests.Euclidean
         [TestCase("1, 0", "-1, 0", false, 180)]
         [TestCase("1, 0", "1, 0", false, 0)]
         [TestCase("0, 1", "1, 0", true, 90)]
-        public void AngleToTest(string v1s, string v2s, bool clockWise, float expected)
+        public void SignedAngleToTest(string v1s, string v2s, bool clockWise, float expected)
         {
             var v1 = Vector2D.Parse(v1s);
             var v2 = Vector2D.Parse(v2s);
@@ -362,6 +386,8 @@ namespace MathNet.Spatial.UnitTests.Euclidean
         [TestCase("-0.99985, -0.01745", "-1, 0", "1°")]
         [TestCase("0.99985, 0.01745", "1, 0","1°")]
         [TestCase("0.99985, -0.01745", "1, 0", "1°")]
+        [TestCase("-0.99985, -0.01745", "1, 0", "179°")]
+        [TestCase("-0.99985, 0.01745", "1, 0", "179°")]
         public void UnSignedAngleTo(string v1s, string v2s, string expectedAngle)
         {
             var v1 = Vector2D.Parse(v1s);

--- a/src/SpatialUnitTests/Euclidean/Vector2DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Vector2DTests.cs
@@ -194,13 +194,14 @@ namespace MathNet.Spatial.UnitTests.Euclidean
             Assert.AreEqual(expected, v2.IsPerpendicularTo(v1, tol));
         }
 
-        [TestCase("1, 0", "1, 0", 1e-4, true)]
-        [TestCase("1, 0", "-1, 0", 1e-4, true)]
-        [TestCase("1, 0", "1, 1", 1e-4, false)]
-        [TestCase("1, 1", "1, 1", 1e-4, true)]
-        [TestCase("1, -1", "-1, 1", 1e-4, true)]
-        [TestCase("1, 0.5", "-1, -0.5", 1e-4, true)]
-        [TestCase("1, 0.5", "-1, 0.5000000005", 1e-4, false)]
+        [TestCase("1, 0", "1, 0", 1e-10, true)]
+        [TestCase("1, 0", "-1, 0", 1e-10, true)]
+        [TestCase("1, 0", "1, 1", 1e-10, false)]
+        [TestCase("1, 1", "1, 1", 1e-10, true)]
+        [TestCase("1, -1", "-1, 1", 1e-10, true)]
+        [TestCase("1, 0.5", "-1, -0.5", 1e-10, true)]
+        [TestCase("1, 0.5", "1, 0.5001", 1e-10, false)]
+        [TestCase("1, 0.5", "1, 0.5001", 1e-8, true)] // Demonstration of the effect of tolerance
         public void IsParallelToByDoubleTolerance(string v1s, string v2s, double tol, bool expected)
         {
             var v1 = Vector2D.Parse(v1s);

--- a/src/SpatialUnitTests/Euclidean/Vector3DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Vector3DTests.cs
@@ -281,6 +281,50 @@ namespace MathNet.Spatial.UnitTests.Euclidean
             Assert.AreEqual(isParalell, firstVector.IsParallelTo(secondVector, 1E-6));
         }
 
+        [TestCase("0,1,0", "0,1, 0", 1e-10, true)]
+        [TestCase("0,1,0", "0,-1, 0", 1e-10, true)]
+        [TestCase("0,1,0", "0,1, 1", 1e-10, false)]
+        [TestCase("0,1,1", "0,1, 1", 1e-10, true)]
+        [TestCase("0,1,-1", "0,-1, 1", 1e-10, true)]
+        [TestCase("0,1,0", "0,1, 0.001", 1e-10, false)]
+        [TestCase("0,1,0", "0,1, -0.001", 1e-10, false)]
+        [TestCase("0,-1,0", "0,1, 0.001", 1e-10, false)]
+        [TestCase("0,-1,0", "0,1, -0.001", 1e-10, false)]
+        [TestCase("0,1,0", "0,1, 0.001", 1e-6, true)]   // These test cases demonstrate the effect of the tolerance
+        [TestCase("0,1,0", "0,1, -0.001", 1e-6, true)]  // These test cases demonstrate the effect of the tolerance
+        [TestCase("0,-1,0", "0,1, 0.001", 1e-6, true)]  // These test cases demonstrate the effect of the tolerance
+        [TestCase("0,-1,0", "0,1, -0.001", 1e-6, true)] // These test cases demonstrate the effect of the tolerance
+        [TestCase("0,1,0.5", "0,-1, -0.5", 1e-10, true)]
+        public void IsParallelToByDoubleTolerance(string v1s, string v2s, double tolerance, bool expected)
+        {
+            var v1 = Vector3D.Parse(v1s);
+            var v2 = Vector3D.Parse(v2s);
+            Assert.AreEqual(expected, v1.IsParallelTo(v2, tolerance));
+            Assert.AreEqual(expected, v2.IsParallelTo(v1, tolerance));
+        }
+
+        [TestCase("0,1,0", "0,1, 0", 1e-10, true)]
+        [TestCase("0,1,0", "0,-1, 0", 1e-10, true)]
+        [TestCase("0,1,0", "0,1, 1", 1e-10, false)]
+        [TestCase("0,1,1", "0,1, 1", 1e-10, true)]
+        [TestCase("0,1,-1", "0,-1, 1", 1e-10, true)]
+        [TestCase("0,1,0", "0,1, 0.001", 1e-10, false)]
+        [TestCase("0,1,0", "0,1, -0.001", 1e-10, false)]
+        [TestCase("0,-1,0", "0,1, 0.001", 1e-10, false)]
+        [TestCase("0,-1,0", "0,1, -0.001", 1e-10, false)]
+        [TestCase("0,1,0", "0,1, 0.001", 1e-6, true)]   // These test cases demonstrate the effect of the tolerance
+        [TestCase("0,1,0", "0,1, -0.001", 1e-6, true)]  // These test cases demonstrate the effect of the tolerance
+        [TestCase("0,-1,0", "0,1, 0.001", 1e-6, true)]  // These test cases demonstrate the effect of the tolerance
+        [TestCase("0,-1,0", "0,1, -0.001", 1e-6, true)] // These test cases demonstrate the effect of the tolerance
+        [TestCase("0,1,0.5", "0,-1, -0.5", 1e-10, true)]
+        public void IsParallelToUnitVectorByDoubleTolerance(string v1s, string v2s, double tolerance, bool expected)
+        {
+            var v1 = Vector3D.Parse(v1s);
+            var v2 = Vector3D.Parse(v2s).Normalize();
+            Assert.AreEqual(expected, v1.IsParallelTo(v2, tolerance));
+            Assert.AreEqual(expected, v2.IsParallelTo(v1, tolerance));
+        }
+
         [TestCase("0,1,0", "0,1, 0", 1e-4, true)]
         [TestCase("0,1,0", "0,-1, 0", 1e-4, true)]
         [TestCase("0,1,0", "0,1, 1", 1e-4, false)]
@@ -303,6 +347,30 @@ namespace MathNet.Spatial.UnitTests.Euclidean
             Assert.AreEqual(expected, v2.IsParallelTo(v1, Angle.FromDegrees(degreesTolerance)));
         }
 
+        [TestCase("0,1,0", "0,1, 0", 1e-4, true)]
+        [TestCase("0,1,0", "0,-1, 0", 1e-4, true)]
+        [TestCase("0,1,0", "0,1, 1", 1e-4, false)]
+        [TestCase("0,1,1", "0,1, 1", 1e-4, true)]
+        [TestCase("0,1,-1", "0,-1, 1", 1e-4, true)]
+        [TestCase("0,1,0", "0,1, 0.001", 0.06, true)]
+        [TestCase("0,1,0", "0,1, -0.001", 0.06, true)]
+        [TestCase("0,-1,0", "0,1, 0.001", 0.06, true)]
+        [TestCase("0,-1,0", "0,1, -0.001", 0.06, true)]
+        [TestCase("0,1,0", "0,1, 0.001", 0.05, false)]
+        [TestCase("0,1,0", "0,1, -0.001", 0.05, false)]
+        [TestCase("0,-1,0", "0,1, 0.001", 0.05, false)]
+        [TestCase("0,-1,0", "0,1, -0.001", 0.05, false)]
+        [TestCase("0,1,0.5", "0,-1, -0.5", 1e-4, true)]
+        public void IsParallelToUnitVectorByAngleTolerance(string v1s, string v2s, double degreesTolerance, bool expected)
+        {
+            var v1 = Vector3D.Parse(v1s);
+            var v2 = Vector3D.Parse(v2s).Normalize();
+            Assert.AreEqual(expected, v1.IsParallelTo(v2, Angle.FromDegrees(degreesTolerance)));
+            Assert.AreEqual(expected, v2.IsParallelTo(v1, Angle.FromDegrees(degreesTolerance)));
+        }
+
+
+
         [TestCase(X, X, false)]
         [TestCase(NegativeX, X, false)]
         [TestCase("-11;0;0", X, false)]
@@ -313,7 +381,7 @@ namespace MathNet.Spatial.UnitTests.Euclidean
         [TestCase(Y, Z, true)]
         [TestCase(Z, Y, true)]
         [TestCase(Z, X, true)]
-        public void IsPerpendicilarToTest(string v1s, string v2s, bool expected)
+        public void IsPerpendicularToTest(string v1s, string v2s, bool expected)
         {
             var v1 = Vector3D.Parse(v1s);
             var v2 = Vector3D.Parse(v2s);

--- a/src/SpatialUnitTests/Euclidean/Vector3DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Vector3DTests.cs
@@ -281,6 +281,28 @@ namespace MathNet.Spatial.UnitTests.Euclidean
             Assert.AreEqual(isParalell, firstVector.IsParallelTo(secondVector, 1E-6));
         }
 
+        [TestCase("0,1,0", "0,1, 0", 1e-4, true)]
+        [TestCase("0,1,0", "0,-1, 0", 1e-4, true)]
+        [TestCase("0,1,0", "0,1, 1", 1e-4, false)]
+        [TestCase("0,1,1", "0,1, 1", 1e-4, true)]
+        [TestCase("0,1,-1", "0,-1, 1", 1e-4, true)]
+        [TestCase("0,1,0", "0,1, 0.001", 0.06, true)]
+        [TestCase("0,1,0", "0,1, -0.001", 0.06, true)]
+        [TestCase("0,-1,0", "0,1, 0.001", 0.06, true)]
+        [TestCase("0,-1,0", "0,1, -0.001", 0.06, true)]
+        [TestCase("0,1,0", "0,1, 0.001", 0.05, false)]
+        [TestCase("0,1,0", "0,1, -0.001", 0.05, false)]
+        [TestCase("0,-1,0", "0,1, 0.001", 0.05, false)]
+        [TestCase("0,-1,0", "0,1, -0.001", 0.05, false)]
+        [TestCase("0,1,0.5", "0,-1, -0.5", 1e-4, true)]
+        public void IsParallelToByAngleTolerance(string v1s, string v2s, double degreesTolerance, bool expected)
+        {
+            var v1 = Vector3D.Parse(v1s);
+            var v2 = Vector3D.Parse(v2s);
+            Assert.AreEqual(expected, v1.IsParallelTo(v2, Angle.FromDegrees(degreesTolerance)));
+            Assert.AreEqual(expected, v2.IsParallelTo(v1, Angle.FromDegrees(degreesTolerance)));
+        }
+
         [TestCase(X, X, false)]
         [TestCase(NegativeX, X, false)]
         [TestCase("-11;0;0", X, false)]


### PR DESCRIPTION
Pull request for Issue #32 submitted for review.

This one turned into something big.  Changed default tolerances to 1e-10, since 1e-6 (which was on the Vector3D class's IsParallelTo method) ended up producing incorrect results with vectors different in the third decimal place.

Lots of unit tests, should be 100% coverage of the methods I added and the old IsParallelTo methods.  

I did not remove all of the old tests, but maybe they ought to be.