### PR TITLE
New convex hull for Polygon2D

### DIFF
--- a/src/Spatial/Euclidean/Polygon2D.cs
+++ b/src/Spatial/Euclidean/Polygon2D.cs
@@ -175,7 +175,7 @@
         }
 
         /// <summary>
-        /// Using the recursive QuickHull algorithm, take an IEnumerable of Point2Ds and compute the
+        /// Using algorithm from Ouellet - https://www.codeproject.com/Articles/1210225/Fast-and-improved-D-Convex-Hull-algorithm-and-its, take an IEnumerable of Point2Ds and computes the
         /// two dimensional convex hull, returning it as a Polygon2D object.
         /// </summary>
         /// <param name="pointList">A list of points</param>
@@ -368,61 +368,6 @@
         public override int GetHashCode()
         {
             return this.Vertices.GetHashCode();
-        }
-
-        /// <summary>
-        /// Recursive method to isolate the points from the working list which lie on the convex hull
-        /// </summary>
-        /// <param name="a">The first point</param>
-        /// <param name="b">The second point</param>
-        /// <param name="workingList">A list of points to be evaluated</param>
-        /// <param name="hullList">A list of points on the convex hull</param>
-        private static void RecursiveHullComputation(Point2D a, Point2D b, List<Point2D> workingList, List<Point2D> hullList)
-        {
-            if (!workingList.Any())
-            {
-                return;
-            }
-
-            if (workingList.Count == 1)
-            {
-                hullList.Add(workingList.First());
-                workingList.Remove(workingList.First());
-                return;
-            }
-
-            // Find the furthest point from the line
-            var chord = a.VectorTo(b);
-            var maxPoint = default(Point2D);
-            var maxDistance = double.MinValue;
-
-            foreach (var point2D in workingList)
-            {
-                var testVector = a.VectorTo(point2D);
-                var projection = testVector.ProjectOn(chord);
-                var rejection = testVector - projection;
-                if (rejection.Length > maxDistance)
-                {
-                    maxDistance = rejection.Length;
-                    maxPoint = point2D;
-                }
-            }
-
-            // Add the point to the hull and remove it from the working list
-            hullList.Add(maxPoint);
-            workingList.Remove(maxPoint);
-
-            // Remove all points from the workinglist inside the new triangle
-            var exclusionTriangle = new Polygon2D(new Point2D[] { a, b, maxPoint });
-            var removeList = workingList.Where(x => exclusionTriangle.EnclosesPoint(x)).ToList();
-            foreach (var point2D in removeList)
-            {
-                workingList.Remove(point2D);
-            }
-
-            // Recurse to the next level
-            RecursiveHullComputation(a, maxPoint, workingList, hullList);
-            RecursiveHullComputation(maxPoint, b, workingList, hullList);
         }
 
         /// <summary>

--- a/src/Spatial/Euclidean/Polygon2D.cs
+++ b/src/Spatial/Euclidean/Polygon2D.cs
@@ -68,10 +68,9 @@
         {
             get
             {
-                var enumerator = this.points.GetEnumerator();
-                while (enumerator.MoveNext())
+                foreach(var point in this.points)
                 {
-                    yield return enumerator.Current;
+                    yield return point;
                 }
             }
         }
@@ -88,10 +87,9 @@
                     this.PopulateEdgeList();
                 }
 
-                var enumerator = this.edges.GetEnumerator();
-                while (enumerator.MoveNext())
+                foreach (var edge in this.edges)
                 {
-                    yield return enumerator.Current;
+                    yield return edge;
                 }
             }
         }

--- a/src/Spatial/Internals/AvlTreeSet/AvlNode.cs
+++ b/src/Spatial/Internals/AvlTreeSet/AvlNode.cs
@@ -1,0 +1,80 @@
+﻿namespace MathNet.Spatial.Internals
+{
+    public sealed class AvlNode<T>
+    {
+        public AvlNode<T> Parent;
+        public AvlNode<T> Left;
+        public AvlNode<T> Right;
+        public T Item;
+        public int Balance;
+
+        /// <summary>
+        /// Non recursive function that return the next ordered node
+        /// </summary>
+        /// <returns></returns>
+        public AvlNode<T> GetNextNode()
+        {
+            AvlNode<T> current;
+
+            if (Right != null)
+            {
+                current = Right;
+                while (current.Left != null)
+                {
+                    current = current.Left;
+                }
+                return current;
+            }
+
+            current = this;
+            while (current.Parent != null)
+            {
+                if (current.Parent.Left == current)
+                {
+                    return current.Parent;
+                }
+
+                current = current.Parent;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Non recursive function that return the previous ordered node
+        /// </summary>
+        /// <returns></returns>
+        public AvlNode<T> GetPreviousNode()
+        {
+            AvlNode<T> current;
+
+            if (Left != null)
+            {
+                current = Left;
+                while (current.Right != null)
+                {
+                    current = current.Right;
+                }
+                return current;
+            }
+
+            current = this;
+            while (current.Parent != null)
+            {
+                if (current.Parent.Right == current)
+                {
+                    return current.Parent;
+                }
+
+                current = current.Parent;
+            }
+
+            return null;
+        }
+
+        public override string ToString()
+        {
+            return $"AvlNode [{Item}], balance: {Balance}, Parent: {Parent?.Item.ToString()}, Left: {Left?.Item.ToString()}, Right: {Right?.Item.ToString()},";
+        }
+    }
+}

--- a/src/Spatial/Internals/AvlTreeSet/AvlNode.cs
+++ b/src/Spatial/Internals/AvlTreeSet/AvlNode.cs
@@ -1,6 +1,6 @@
 ﻿namespace MathNet.Spatial.Internals
 {
-    public sealed class AvlNode<T>
+    internal sealed class AvlNode<T>
     {
         public AvlNode<T> Parent;
         public AvlNode<T> Left;

--- a/src/Spatial/Internals/AvlTreeSet/AvlNodeItemEnumerator.cs
+++ b/src/Spatial/Internals/AvlTreeSet/AvlNodeItemEnumerator.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-
-namespace MathNet.Spatial.Internals
+﻿namespace MathNet.Spatial.Internals
 {
-    public class AvlNodeItemEnumerator<T> : IEnumerator<T>
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    internal class AvlNodeItemEnumerator<T> : IEnumerator<T>
     {
         private AvlNode<T> current = null;
         private AvlTreeSet<T> avlTree;

--- a/src/Spatial/Internals/AvlTreeSet/AvlNodeItemEnumerator.cs
+++ b/src/Spatial/Internals/AvlTreeSet/AvlNodeItemEnumerator.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace MathNet.Spatial.Internals
+{
+    public class AvlNodeItemEnumerator<T> : IEnumerator<T>
+    {
+        private AvlNode<T> current = null;
+        private AvlTreeSet<T> avlTree;
+
+        public AvlNodeItemEnumerator(AvlTreeSet<T> avlTree)
+        {
+            this.avlTree = avlTree ?? throw new ArgumentNullException("avlTree can't be null");
+        }
+
+        public T Current
+        {
+            get
+            {
+                if (this.current == null)
+                {
+                    throw new InvalidOperationException("Current is invalid");
+                }
+
+                return this.current.Item;
+            }
+        }
+
+        object IEnumerator.Current => this.Current;
+
+        public void Dispose()
+        {
+        }
+
+        public bool MoveNext()
+        {
+            if (this.current == null)
+            {
+                this.current = this.avlTree.GetFirstNode();
+            }
+            else
+            {
+                this.current = this.current.GetNextNode();
+            }
+
+            if (this.current == null) // Should check for an empty tree too :-) 
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public void Reset()
+        {
+            this.current = null;
+        }
+    }
+}

--- a/src/Spatial/Internals/AvlTreeSet/AvlTreeSet.cs
+++ b/src/Spatial/Internals/AvlTreeSet/AvlTreeSet.cs
@@ -1,18 +1,18 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading;
-
-namespace MathNet.Spatial.Internals
+﻿namespace MathNet.Spatial.Internals
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Runtime.CompilerServices;
+    using System.Text;
+    using System.Threading;
+
     /// <summary>
     /// 2016-12-08, Eric Ouellet
     /// The code is an adapted version of BitLush AvlTree: https://bitlush.com/blog/efficient-avl-tree-in-c-sharp
     /// </summary>
-    public class AvlTreeSet<T> : IEnumerable<T>, IEnumerable, ICollection<T>, ICollection// ISet<T>
+    internal class AvlTreeSet<T> : IEnumerable<T>, IEnumerable, ICollection<T>, ICollection// ISet<T>
     {
         private IComparer<T> comparer;
         private AvlNode<T> root;
@@ -23,7 +23,6 @@ namespace MathNet.Spatial.Internals
             this.comparer = comparer;
         }
 
-        // ******************************************************************
         public AvlTreeSet() : this(Comparer<T>.Default)
         {
         }

--- a/src/Spatial/Internals/AvlTreeSet/AvlTreeSet.cs
+++ b/src/Spatial/Internals/AvlTreeSet/AvlTreeSet.cs
@@ -1,0 +1,814 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace MathNet.Spatial.Internals
+{
+    /// <summary>
+    /// 2016-12-08, Eric Ouellet
+    /// The code is an adapted version of BitLush AvlTree: https://bitlush.com/blog/efficient-avl-tree-in-c-sharp
+    /// </summary>
+    public class AvlTreeSet<T> : IEnumerable<T>, IEnumerable, ICollection<T>, ICollection// ISet<T>
+    {
+        private IComparer<T> comparer;
+        private AvlNode<T> root;
+        protected int count = 0;
+
+        public AvlTreeSet(IComparer<T> comparer)
+        {
+            this.comparer = comparer;
+        }
+
+        // ******************************************************************
+        public AvlTreeSet() : this(Comparer<T>.Default)
+        {
+        }
+
+        public AvlNode<T> Root => root;
+
+        public int Count => count;
+
+        private object _syncRoot;
+
+        public object SyncRoot
+        {
+            get
+            {
+                if (this._syncRoot == null)
+                    Interlocked.CompareExchange(ref this._syncRoot, new object(), (object)null);
+                return this._syncRoot;
+            }
+        }
+
+        public bool IsSynchronized => true;
+
+        public bool IsReadOnly => false;
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return new AvlNodeItemEnumerator<T>(this);
+        }
+
+        protected AvlNode<T> GetNode(T item)
+        {
+            AvlNode<T> node = root;
+
+            while (node != null)
+            {
+                int compareResult = comparer.Compare(item, node.Item);
+                if (compareResult < 0)
+                {
+                    node = node.Left;
+                }
+                else if (compareResult > 0)
+                {
+                    node = node.Right;
+                }
+                else
+                {
+                    return node;
+                }
+            }
+
+            return null;
+        }
+
+        public bool Contains(T item)
+        {
+            AvlNode<T> node = root;
+
+            while (node != null)
+            {
+                int compareResult = this.comparer.Compare(item, node.Item);
+                if (compareResult < 0)
+                {
+                    node = node.Left;
+                }
+                else if (compareResult > 0)
+                {
+                    node = node.Right;
+                }
+                else
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public virtual bool Add(T item)
+        {
+            AvlNode<T> node = root;
+
+            while (node != null)
+            {
+                int compare = comparer.Compare(item, node.Item);
+
+                if (compare < 0)
+                {
+                    AvlNode<T> left = node.Left;
+
+                    if (left == null)
+                    {
+                        node.Left = new AvlNode<T> { Item = item, Parent = node };
+                        AddBalance(node, 1);
+                        return true;
+                    }
+                    else
+                    {
+                        node = left;
+                    }
+                }
+                else if (compare > 0)
+                {
+                    AvlNode<T> right = node.Right;
+
+                    if (right == null)
+                    {
+                        node.Right = new AvlNode<T> { Item = item, Parent = node };
+                        AddBalance(node, -1);
+                        return true;
+                    }
+                    else
+                    {
+                        node = right;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            this.root = new AvlNode<T> { Item = item };
+            this.count++;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Should always be called for any inserted node
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="balance"></param>
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void AddBalance(AvlNode<T> node, int balance)
+        {
+            count++;
+
+            while (node != null)
+            {
+                balance = (node.Balance += balance);
+
+                if (balance == 0)
+                {
+                    break;
+                }
+
+                if (balance == 2)
+                {
+                    if (node.Left.Balance == 1)
+                    {
+                        RotateRight(node);
+                    }
+                    else
+                    {
+                        RotateLeftRight(node);
+                    }
+
+                    break;
+                }
+
+                if (balance == -2)
+                {
+                    if (node.Right.Balance == -1)
+                    {
+                        RotateLeft(node);
+                    }
+                    else
+                    {
+                        RotateRightLeft(node);
+                    }
+
+                    break;
+                }
+
+                AvlNode<T> parent = node.Parent;
+
+                if (parent != null)
+                {
+                    balance = parent.Left == node ? 1 : -1;
+                }
+
+                node = parent;
+            }
+        }
+
+        protected AvlNode<T> RotateLeft(AvlNode<T> node)
+        {
+            AvlNode<T> right = node.Right;
+            AvlNode<T> rightLeft = right.Left;
+            AvlNode<T> parent = node.Parent;
+
+            right.Parent = parent;
+            right.Left = node;
+            node.Right = rightLeft;
+            node.Parent = right;
+
+            if (rightLeft != null)
+            {
+                rightLeft.Parent = node;
+            }
+
+            if (node == root)
+            {
+                root = right;
+            }
+            else if (parent.Right == node)
+            {
+                parent.Right = right;
+            }
+            else
+            {
+                parent.Left = right;
+            }
+
+            right.Balance++;
+            node.Balance = -right.Balance;
+
+            return right;
+        }
+
+        protected AvlNode<T> RotateRight(AvlNode<T> node)
+        {
+            AvlNode<T> left = node.Left;
+            AvlNode<T> leftRight = left.Right;
+            AvlNode<T> parent = node.Parent;
+
+            left.Parent = parent;
+            left.Right = node;
+            node.Left = leftRight;
+            node.Parent = left;
+
+            if (leftRight != null)
+            {
+                leftRight.Parent = node;
+            }
+
+            if (node == root)
+            {
+                root = left;
+            }
+            else if (parent.Left == node)
+            {
+                parent.Left = left;
+            }
+            else
+            {
+                parent.Right = left;
+            }
+
+            left.Balance--;
+            node.Balance = -left.Balance;
+
+            return left;
+        }
+
+        protected AvlNode<T> RotateLeftRight(AvlNode<T> node)
+        {
+            AvlNode<T> left = node.Left;
+            AvlNode<T> leftRight = left.Right;
+            AvlNode<T> parent = node.Parent;
+            AvlNode<T> leftRightRight = leftRight.Right;
+            AvlNode<T> leftRightLeft = leftRight.Left;
+
+            leftRight.Parent = parent;
+            node.Left = leftRightRight;
+            left.Right = leftRightLeft;
+            leftRight.Left = left;
+            leftRight.Right = node;
+            left.Parent = leftRight;
+            node.Parent = leftRight;
+
+            if (leftRightRight != null)
+            {
+                leftRightRight.Parent = node;
+            }
+
+            if (leftRightLeft != null)
+            {
+                leftRightLeft.Parent = left;
+            }
+
+            if (node == root)
+            {
+                root = leftRight;
+            }
+            else if (parent.Left == node)
+            {
+                parent.Left = leftRight;
+            }
+            else
+            {
+                parent.Right = leftRight;
+            }
+
+            if (leftRight.Balance == -1)
+            {
+                node.Balance = 0;
+                left.Balance = 1;
+            }
+            else if (leftRight.Balance == 0)
+            {
+                node.Balance = 0;
+                left.Balance = 0;
+            }
+            else
+            {
+                node.Balance = -1;
+                left.Balance = 0;
+            }
+
+            leftRight.Balance = 0;
+
+            return leftRight;
+        }
+
+        protected AvlNode<T> RotateRightLeft(AvlNode<T> node)
+        {
+            AvlNode<T> right = node.Right;
+            AvlNode<T> rightLeft = right.Left;
+            AvlNode<T> parent = node.Parent;
+            AvlNode<T> rightLeftLeft = rightLeft.Left;
+            AvlNode<T> rightLeftRight = rightLeft.Right;
+
+            rightLeft.Parent = parent;
+            node.Right = rightLeftLeft;
+            right.Left = rightLeftRight;
+            rightLeft.Right = right;
+            rightLeft.Left = node;
+            right.Parent = rightLeft;
+            node.Parent = rightLeft;
+
+            if (rightLeftLeft != null)
+            {
+                rightLeftLeft.Parent = node;
+            }
+
+            if (rightLeftRight != null)
+            {
+                rightLeftRight.Parent = right;
+            }
+
+            if (node == root)
+            {
+                root = rightLeft;
+            }
+            else if (parent.Right == node)
+            {
+                parent.Right = rightLeft;
+            }
+            else
+            {
+                parent.Left = rightLeft;
+            }
+
+            if (rightLeft.Balance == 1)
+            {
+                node.Balance = 0;
+                right.Balance = -1;
+            }
+            else if (rightLeft.Balance == 0)
+            {
+                node.Balance = 0;
+                right.Balance = 0;
+            }
+            else
+            {
+                node.Balance = 1;
+                right.Balance = 0;
+            }
+
+            rightLeft.Balance = 0;
+
+            return rightLeft;
+        }
+
+        public virtual bool Remove(T item)
+        {
+            AvlNode<T> node = root;
+
+            while (node != null)
+            {
+                if (this.comparer.Compare(item, node.Item) < 0)
+                {
+                    node = node.Left;
+                }
+                else if (this.comparer.Compare(item, node.Item) > 0)
+                {
+                    node = node.Right;
+                }
+                else
+                {
+                    this.RemoveNode(node);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        protected void RemoveNode(AvlNode<T> node)
+        {
+            this.count--;
+
+            AvlNode<T> left = node.Left;
+            AvlNode<T> right = node.Right;
+
+            if (left == null)
+            {
+                if (right == null)
+                {
+                    if (node == root)
+                    {
+                        root = null;
+                    }
+                    else
+                    {
+                        if (node.Parent.Left == node)
+                        {
+                            node.Parent.Left = null;
+
+                            RemoveBalance(node.Parent, -1);
+                        }
+                        else if (node.Parent.Right == node)
+                        {
+                            node.Parent.Right = null;
+
+                            RemoveBalance(node.Parent, 1);
+                        }
+                    }
+                }
+                else
+                {
+                    Replace(node, right);
+
+                    RemoveBalance(node, 0);
+                }
+            }
+            else if (right == null)
+            {
+                Replace(node, left);
+
+                RemoveBalance(node, 0);
+            }
+            else
+            {
+                AvlNode<T> successor = right;
+
+                if (successor.Left == null)
+                {
+                    AvlNode<T> parent = node.Parent;
+
+                    successor.Parent = parent;
+                    successor.Left = left;
+                    successor.Balance = node.Balance;
+
+                    left.Parent = successor;
+
+                    if (node == root)
+                    {
+                        root = successor;
+                    }
+                    else
+                    {
+                        if (parent.Left == node)
+                        {
+                            parent.Left = successor;
+                        }
+                        else
+                        {
+                            parent.Right = successor;
+                        }
+                    }
+
+                    RemoveBalance(successor, 1);
+                }
+                else
+                {
+                    while (successor.Left != null)
+                    {
+                        successor = successor.Left;
+                    }
+
+                    AvlNode<T> parent = node.Parent;
+                    AvlNode<T> successorParent = successor.Parent;
+                    AvlNode<T> successorRight = successor.Right;
+
+                    if (successorParent.Left == successor)
+                    {
+                        successorParent.Left = successorRight;
+                    }
+                    else
+                    {
+                        successorParent.Right = successorRight;
+                    }
+
+                    if (successorRight != null)
+                    {
+                        successorRight.Parent = successorParent;
+                    }
+
+                    successor.Parent = parent;
+                    successor.Left = left;
+                    successor.Balance = node.Balance;
+                    successor.Right = right;
+                    right.Parent = successor;
+
+                    left.Parent = successor;
+
+                    if (node == root)
+                    {
+                        root = successor;
+                    }
+                    else
+                    {
+                        if (parent.Left == node)
+                        {
+                            parent.Left = successor;
+                        }
+                        else
+                        {
+                            parent.Right = successor;
+                        }
+                    }
+
+                    RemoveBalance(successorParent, -1);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Shoould always be called for any removed node
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="balance"></param>
+        protected void RemoveBalance(AvlNode<T> node, int balance)
+        {
+            while (node != null)
+            {
+                balance = node.Balance += balance;
+
+                if (balance == 2)
+                {
+                    if (node.Left.Balance >= 0)
+                    {
+                        node = RotateRight(node);
+
+                        if (node.Balance == -1)
+                        {
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        node = this.RotateLeftRight(node);
+                    }
+                }
+                else if (balance == -2)
+                {
+                    if (node.Right.Balance <= 0)
+                    {
+                        node = RotateLeft(node);
+
+                        if (node.Balance == 1)
+                        {
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        node = RotateRightLeft(node);
+                    }
+                }
+                else if (balance != 0)
+                {
+                    return;
+                }
+
+                AvlNode<T> parent = node.Parent;
+
+                if (parent != null)
+                {
+                    balance = parent.Left == node ? -1 : 1;
+                }
+
+                node = parent;
+            }
+        }
+
+        private static void Replace(AvlNode<T> target, AvlNode<T> source)
+        {
+            AvlNode<T> left = source.Left;
+            AvlNode<T> right = source.Right;
+
+            target.Balance = source.Balance;
+            target.Item = source.Item;
+            target.Left = left;
+            target.Right = right;
+
+            if (left != null)
+            {
+                left.Parent = target;
+            }
+
+            if (right != null)
+            {
+                right.Parent = target;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public T GetFirstItem()
+        {
+            AvlNode<T> node = GetFirstNode();
+            if (node != null)
+            {
+                return node.Item;
+            }
+
+            return default(T);
+        }
+
+        public AvlNode<T> GetFirstNode()
+        {
+            if (Root != null)
+            {
+                AvlNode<T> current = Root;
+                while (current.Left != null)
+                {
+                    current = current.Left;
+                }
+
+                return current;
+            }
+
+            return null;
+        }
+
+        public T GetLastItem()
+        {
+            AvlNode<T> node = GetLastNode();
+            if (node != null)
+            {
+                return node.Item;
+            }
+
+            return default(T);
+        }
+
+        public AvlNode<T> GetLastNode()
+        {
+            if (this.Root != null)
+            {
+                AvlNode<T> current = this.Root;
+                while (current.Right != null)
+                {
+                    current = current.Right;
+                }
+
+                return current;
+            }
+
+            return null;
+        }
+
+        private int RecursiveCount(AvlNode<T> node)
+        {
+            if (node == null)
+            {
+                return 0;
+            }
+
+            return 1 + this.RecursiveCount(node.Left) + this.RecursiveCount(node.Right);
+        }
+
+        void ICollection<T>.Add(T item)
+        {
+            Add(item);
+        }
+
+        public void Clear()
+        {
+            this.root = null;
+            this.count = 0;
+        }
+
+        public void CopyTo(T[] array, int index, int count)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException("'array' can't be null");
+            }
+
+            if (index < 0)
+            {
+                throw new ArgumentException("'index' can't be null");
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("'count' should be greater or equal to 0");
+            }
+
+            if (index > array.Length || count > array.Length - index)
+            {
+                throw new ArgumentException("The array size is not big enough to get all items");
+            }
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            int indexIter = 0;
+            int indexArray = 0;
+
+            AvlNode<T> current = this.GetFirstNode();
+            while (current.GetNextNode() != null)
+            {
+                if (indexIter >= index)
+                {
+                    array[indexArray] = current.Item;
+                    indexArray++;
+                    count--;
+                    if (count == 0)
+                    {
+                        return;
+                    }
+                }
+
+                indexIter++;
+            }
+
+            /*
+            foreach (AvlNode<T> node in this.Nodes())
+            {
+                if (indexIter >= index)
+                {
+                    array[indexArray] = node.Item;
+                    indexArray++;
+                    count--;
+                    if (count == 0)
+                    {
+                        return;
+                    }
+                }
+
+                indexIter++;
+            }*/
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            SortedSet<double> t = new SortedSet<double>();
+            this.CopyTo(array, arrayIndex, this.Count);
+        }
+
+        public void CopyTo(Array array, int index)
+        {
+            this.CopyTo(array as T[], index, this.Count);
+        }
+
+        private int RecursiveGetChildMaxHeight(AvlNode<T> node)
+        {
+            if (node == null)
+            {
+                return 0;
+            }
+
+            int leftHeight = 0;
+            if (node.Left != null)
+            {
+                leftHeight = this.RecursiveGetChildMaxHeight(node.Left);
+            }
+
+            int rightHeight = 0;
+            if (node.Right != null)
+            {
+                rightHeight = this.RecursiveGetChildMaxHeight(node.Right);
+            }
+
+            return 1 + Math.Max(leftHeight, rightHeight);
+        }
+    }
+}

--- a/src/Spatial/Internals/ConvexHull/ConvexHull.cs
+++ b/src/Spatial/Internals/ConvexHull/ConvexHull.cs
@@ -1,0 +1,1421 @@
+﻿/// <summary>
+/// Based upon the work of Lui, Chen and Ouellet - https://www.codeproject.com/Articles/1210225/Fast-and-improved-D-Convex-Hull-algorithm-and-its
+/// </summary>
+namespace MathNet.Spatial.Internals
+{
+    using MathNet.Spatial.Euclidean;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    internal class ConvexHull
+    {
+        private struct Limit
+        {
+            internal MutablePoint Q1Top, Q2Top, Q2Left, Q3Left, Q3Bottom, Q4Bottom, Q4Right, Q1Right;
+
+            internal Limit(MutablePoint pt)
+            {
+                Q1Top = pt;
+                Q2Top = pt;
+                Q2Left = pt;
+                Q3Left = pt;
+                Q3Bottom = pt;
+                Q4Bottom = pt;
+                Q4Right = pt;
+                Q1Right = pt;
+            }
+
+            internal Limit Copy()
+            {
+                Limit limit = new Limit
+                {
+                    Q1Top = Q1Top,
+                    Q2Top = Q2Top,
+                    Q2Left = Q2Left,
+                    Q3Left = Q3Left,
+                    Q3Bottom = Q3Bottom,
+                    Q4Bottom = Q4Bottom,
+                    Q4Right = Q4Right,
+                    Q1Right = Q1Right
+                };
+
+                return limit;
+            }
+        }
+
+
+        // Quadrant: Q2 | Q1
+        //	         -------
+        //           Q3 | Q4
+
+        private Quadrant _q1;
+        private Quadrant _q2;
+        private Quadrant _q3;
+        private Quadrant _q4;
+
+        private MutablePoint[] _listOfPoint;
+        private bool _shouldCloseTheGraph;
+
+        // ******************************************************************
+        public ConvexHull(IEnumerable<Point2D> listOfPoint, bool shouldCloseTheGraph = true, int initialResultGuessSize = 0)
+        {
+            List<MutablePoint> l = new List<MutablePoint>();
+            foreach (var point in listOfPoint)
+            {
+                MutablePoint p = new MutablePoint(point.X, point.Y);
+                l.Add(p);
+            }
+
+            Init(l.ToArray(), shouldCloseTheGraph);
+        }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsPointToTheRightOfOthers(MutablePoint p1, MutablePoint p2, MutablePoint ptToCheck)
+        {
+            return ((p2.X - p1.X) * (ptToCheck.Y - p1.Y)) - ((p2.Y - p1.Y) * (ptToCheck.X - p1.X)) < 0;
+        }
+
+        private void Init(MutablePoint[] listOfPoint, bool shouldCloseTheGraph)
+        {
+            _listOfPoint = listOfPoint;
+            _shouldCloseTheGraph = shouldCloseTheGraph;
+
+            _q1 = new QuadrantSpecific1(this._listOfPoint, (a, b) => (a.X > b.X) ? -1 : (a.X < b.X) ? 1 : 0);
+            _q2 = new QuadrantSpecific2(this._listOfPoint, (a, b) => (a.X > b.X) ? -1 : (a.X < b.X) ? 1 : 0);
+            _q3 = new QuadrantSpecific3(this._listOfPoint, (a, b) => (a.X < b.X) ? -1 : (a.X > b.X) ? 1 : 0);
+            _q4 = new QuadrantSpecific4(this._listOfPoint, (a, b) => (a.X < b.X) ? -1 : (a.X > b.X) ? 1 : 0);
+        }
+
+        private bool IsQuadrantAreDisjoint()
+        {
+            if (IsPointToTheRightOfOthers(_q1.FirstPoint, _q1.LastPoint, _q3.RootPoint))
+            {
+                return false;
+            }
+
+            if (IsPointToTheRightOfOthers(_q2.FirstPoint, _q2.LastPoint, _q4.RootPoint))
+            {
+                return false;
+            }
+
+            if (IsPointToTheRightOfOthers(_q3.FirstPoint, _q3.LastPoint, _q1.RootPoint))
+            {
+                return false;
+            }
+
+            if (IsPointToTheRightOfOthers(_q4.FirstPoint, _q4.LastPoint, _q2.RootPoint))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="threadUsage">Using ConvexHullThreadUsage.All will only use all thread for the first pass (se quadrant limits) then use only 4 threads for pass 2 (which is the actual limit).</param>
+        public void CalcConvexHull()
+        {
+            if (this.IsZeroData())
+            {
+                return;
+            }
+
+            SetQuadrantLimitsOneThread();
+
+            _q1.Prepare();
+            _q2.Prepare();
+            _q3.Prepare();
+            _q4.Prepare();
+
+            MutablePoint q1Root = _q1.RootPoint;
+            MutablePoint q2Root = _q2.RootPoint;
+            MutablePoint q3Root = _q3.RootPoint;
+            MutablePoint q4Root = _q4.RootPoint;
+
+            // Main Loop to extract ConvexHullPoints
+            MutablePoint[] points = _listOfPoint;
+            int index = 0;
+            int pointCount = points.Length;
+
+            if (points != null)
+            {
+                MutablePoint point;
+
+                if (IsQuadrantAreDisjoint())
+                {
+                    Q1First:
+                    if (index < pointCount)
+                    {
+                        point = points[index++];
+
+                        if (point.X > q1Root.X && point.Y > q1Root.Y)
+                        {
+                            _q1.ProcessPoint(ref point);
+                            goto Q1First;
+                        }
+
+                        if (point.X < q2Root.X && point.Y > q2Root.Y)
+                        {
+                            _q2.ProcessPoint(ref point);
+                            goto Q2First;
+                        }
+
+                        if (point.X < q3Root.X && point.Y < q3Root.Y)
+                        {
+                            _q3.ProcessPoint(ref point);
+                            goto Q3First;
+                        }
+
+                        if (point.X > q4Root.X && point.Y < q4Root.Y)
+                        {
+                            _q4.ProcessPoint(ref point);
+                            goto Q4First;
+                        }
+
+                        goto Q1First;
+                    }
+                    else
+                    {
+                        goto End;
+                    }
+
+                    Q2First:
+                    if (index < pointCount)
+                    {
+                        point = points[index++];
+
+                        if (point.X < q2Root.X && point.Y > q2Root.Y)
+                        {
+                            _q2.ProcessPoint(ref point);
+                            goto Q2First;
+                        }
+
+                        if (point.X < q3Root.X && point.Y < q3Root.Y)
+                        {
+                            _q3.ProcessPoint(ref point);
+                            goto Q3First;
+                        }
+
+                        if (point.X > q4Root.X && point.Y < q4Root.Y)
+                        {
+                            _q4.ProcessPoint(ref point);
+                            goto Q4First;
+                        }
+
+                        if (point.X > q1Root.X && point.Y > q1Root.Y)
+                        {
+                            _q1.ProcessPoint(ref point);
+                            goto Q1First;
+                        }
+
+                        goto Q2First;
+                    }
+                    else
+                    {
+                        goto End;
+                    }
+
+                    Q3First:
+                    if (index < pointCount)
+                    {
+                        point = points[index++];
+
+                        if (point.X < q3Root.X && point.Y < q3Root.Y)
+                        {
+                            _q3.ProcessPoint(ref point);
+                            goto Q3First;
+                        }
+
+                        if (point.X > q4Root.X && point.Y < q4Root.Y)
+                        {
+                            _q4.ProcessPoint(ref point);
+                            goto Q4First;
+                        }
+
+                        if (point.X > q1Root.X && point.Y > q1Root.Y)
+                        {
+                            _q1.ProcessPoint(ref point);
+                            goto Q1First;
+                        }
+
+                        if (point.X < q2Root.X && point.Y > q2Root.Y)
+                        {
+                            _q2.ProcessPoint(ref point);
+                            goto Q2First;
+                        }
+
+                        goto Q3First;
+                    }
+                    else
+                    {
+                        goto End;
+                    }
+
+                    Q4First:
+                    if (index < pointCount)
+                    {
+                        point = points[index++];
+
+                        if (point.X > q4Root.X && point.Y < q4Root.Y)
+                        {
+                            _q4.ProcessPoint(ref point);
+                            goto Q4First;
+                        }
+
+                        if (point.X > q1Root.X && point.Y > q1Root.Y)
+                        {
+                            _q1.ProcessPoint(ref point);
+                            goto Q1First;
+                        }
+
+                        if (point.X < q2Root.X && point.Y > q2Root.Y)
+                        {
+                            _q2.ProcessPoint(ref point);
+                            goto Q2First;
+                        }
+
+                        if (point.X < q3Root.X && point.Y < q3Root.Y)
+                        {
+                            _q3.ProcessPoint(ref point);
+                            goto Q3First;
+                        }
+
+                        goto Q4First;
+                    }
+                    else
+                    {
+                        goto End;
+                    }
+                }
+                else  // Not disjoint ***********************************************************************************
+                {
+                    Q1First:
+                    if (index < pointCount)
+                    {
+                        point = points[index++];
+
+                        if (point.X > q1Root.X && point.Y > q1Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q1.FirstPoint, _q1.LastPoint, point))
+                            {
+                                _q1.ProcessPoint(ref point);
+                                goto Q1First;
+                            }
+
+                            if (point.X < q3Root.X && point.Y < q3Root.Y)
+                            {
+                                if (IsPointToTheRightOfOthers(_q3.FirstPoint, _q3.LastPoint, point))
+                                {
+                                    _q3.ProcessPoint(ref point);
+                                }
+
+                                goto Q3First;
+                            }
+
+                            goto Q1First;
+                        }
+
+                        if (point.X < q2Root.X && point.Y > q2Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q2.FirstPoint, _q2.LastPoint, point))
+                            {
+                                _q2.ProcessPoint(ref point);
+                                goto Q2First;
+                            }
+
+                            if (point.X > q4Root.X && point.Y < q4Root.Y)
+                            {
+                                if (IsPointToTheRightOfOthers(_q4.FirstPoint, _q4.LastPoint, point))
+                                {
+                                    _q4.ProcessPoint(ref point);
+                                }
+
+                                goto Q4First;
+                            }
+
+                            goto Q2First;
+                        }
+
+                        if (point.X < q3Root.X && point.Y < q3Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q3.FirstPoint, _q3.LastPoint, point))
+                            {
+                                _q3.ProcessPoint(ref point);
+                            }
+
+                            goto Q3First;
+                        }
+                        else if (point.X > q4Root.X && point.Y < q4Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q4.FirstPoint, _q4.LastPoint, point))
+                            {
+                                _q4.ProcessPoint(ref point);
+                            }
+
+                            goto Q4First;
+                        }
+
+                        goto Q1First;
+                    }
+                    else
+                    {
+                        goto End;
+                    }
+
+                    Q2First:
+                    if (index < pointCount)
+                    {
+                        point = points[index++];
+
+                        if (point.X < q2Root.X && point.Y > q2Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q2.FirstPoint, _q2.LastPoint, point))
+                            {
+                                _q2.ProcessPoint(ref point);
+                                goto Q2First;
+                            }
+
+                            if (point.X > q4Root.X && point.Y < q4Root.Y)
+                            {
+                                if (IsPointToTheRightOfOthers(_q4.FirstPoint, _q4.LastPoint, point))
+                                {
+                                    _q4.ProcessPoint(ref point);
+                                }
+
+                                goto Q4First;
+                            }
+
+                            goto Q2First;
+                        }
+
+                        if (point.X < q3Root.X && point.Y < q3Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q3.FirstPoint, _q3.LastPoint, point))
+                            {
+                                _q3.ProcessPoint(ref point);
+                                goto Q3First;
+                            }
+
+                            if (point.X > q1Root.X && point.Y > q1Root.Y)
+                            {
+                                if (IsPointToTheRightOfOthers(_q1.FirstPoint, _q1.LastPoint, point))
+                                {
+                                    _q1.ProcessPoint(ref point);
+                                }
+
+                                goto Q1First;
+                            }
+
+                            goto Q3First;
+                        }
+
+                        if (point.X > q4Root.X && point.Y < q4Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q4.FirstPoint, _q4.LastPoint, point))
+                            {
+                                _q4.ProcessPoint(ref point);
+                            }
+
+                            goto Q4First;
+                        }
+                        else if (point.X > q1Root.X && point.Y > q1Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q1.FirstPoint, _q1.LastPoint, point))
+                            {
+                                _q1.ProcessPoint(ref point);
+                            }
+
+                            goto Q1First;
+                        }
+
+                        goto Q2First;
+                    }
+                    else
+                    {
+                        goto End;
+                    }
+
+                    Q3First:
+                    if (index < pointCount)
+                    {
+                        point = points[index++];
+
+                        if (point.X < q3Root.X && point.Y < q3Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q3.FirstPoint, _q3.LastPoint, point))
+                            {
+                                _q3.ProcessPoint(ref point);
+                                goto Q3First;
+                            }
+
+                            if (point.X > q1Root.X && point.Y > q1Root.Y)
+                            {
+                                if (IsPointToTheRightOfOthers(_q1.FirstPoint, _q1.LastPoint, point))
+                                {
+                                    _q1.ProcessPoint(ref point);
+                                }
+
+                                goto Q1First;
+                            }
+
+                            goto Q3First;
+                        }
+
+                        if (point.X > q4Root.X && point.Y < q4Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q4.FirstPoint, _q4.LastPoint, point))
+                            {
+                                _q4.ProcessPoint(ref point);
+                                goto Q4First;
+                            }
+
+                            if (point.X < q2Root.X && point.Y > q2Root.Y)
+                            {
+                                if (IsPointToTheRightOfOthers(_q2.FirstPoint, _q2.LastPoint, point))
+                                {
+                                    _q2.ProcessPoint(ref point);
+                                }
+
+                                goto Q2First;
+                            }
+
+                            goto Q4First;
+                        }
+
+                        if (point.X > q1Root.X && point.Y > q1Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q1.FirstPoint, _q1.LastPoint, point))
+                            {
+                                _q1.ProcessPoint(ref point);
+                                goto Q1First;
+                            }
+                        }
+                        else if (point.X < q2Root.X && point.Y > q2Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q2.FirstPoint, _q2.LastPoint, point))
+                            {
+                                _q2.ProcessPoint(ref point);
+                                goto Q2First;
+                            }
+                        }
+
+                        goto Q3First;
+                    }
+                    else
+                    {
+                        goto End;
+                    }
+
+                    Q4First:
+                    if (index < pointCount)
+                    {
+                        point = points[index++];
+
+                        if (point.X > q4Root.X && point.Y < q4Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q4.FirstPoint, _q4.LastPoint, point))
+                            {
+                                _q4.ProcessPoint(ref point);
+                                goto Q4First;
+                            }
+
+                            if (point.X < q2Root.X && point.Y > q2Root.Y)
+                            {
+                                if (IsPointToTheRightOfOthers(_q2.FirstPoint, _q2.LastPoint, point))
+                                {
+                                    _q2.ProcessPoint(ref point);
+                                }
+
+                                goto Q2First;
+                            }
+
+                            goto Q4First;
+                        }
+
+                        if (point.X > q1Root.X && point.Y > q1Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q1.FirstPoint, _q1.LastPoint, point))
+                            {
+                                _q1.ProcessPoint(ref point);
+                                goto Q1First;
+                            }
+
+                            if (point.X < q3Root.X && point.Y < q3Root.Y)
+                            {
+                                if (IsPointToTheRightOfOthers(_q3.FirstPoint, _q3.LastPoint, point))
+                                {
+                                    _q3.ProcessPoint(ref point);
+                                }
+
+                                goto Q3First;
+                            }
+
+                            goto Q1First;
+                        }
+
+                        if (point.X < q3Root.X && point.Y < q3Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q3.FirstPoint, _q3.LastPoint, point))
+                            {
+                                _q3.ProcessPoint(ref point);
+                                goto Q3First;
+                            }
+                        }
+
+                        if (point.X < q2Root.X && point.Y > q2Root.Y)
+                        {
+                            if (IsPointToTheRightOfOthers(_q2.FirstPoint, _q2.LastPoint, point))
+                            {
+                                _q2.ProcessPoint(ref point);
+                                goto Q2First;
+                            }
+                        }
+
+                        goto Q4First;
+                    }
+                    else
+                    {
+                        goto End;
+                    }
+                }
+
+                End:
+                { }
+            }
+        }
+
+        private void SetQuadrantLimitsOneThread()
+        {
+            MutablePoint ptFirst = this._listOfPoint.First();
+
+            // Find the quadrant limits (maximum x and y)
+
+            double right, topLeft, topRight, left, bottomLeft, bottomRight;
+            right = topLeft = topRight = left = bottomLeft = bottomRight = ptFirst.X;
+
+            double top, rightTop, rightBottom, bottom, leftTop, leftBottom;
+            top = rightTop = rightBottom = bottom = leftTop = leftBottom = ptFirst.Y;
+
+            foreach (MutablePoint pt in _listOfPoint)
+            {
+                if (pt.X >= right)
+                {
+                    if (pt.X == right)
+                    {
+                        if (pt.Y > rightTop)
+                        {
+                            rightTop = pt.Y;
+                        }
+                        else
+                        {
+                            if (pt.Y < rightBottom)
+                            {
+                                rightBottom = pt.Y;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        right = pt.X;
+                        rightTop = rightBottom = pt.Y;
+                    }
+                }
+
+                if (pt.X <= left)
+                {
+                    if (pt.X == left)
+                    {
+                        if (pt.Y > leftTop)
+                        {
+                            leftTop = pt.Y;
+                        }
+                        else
+                        {
+                            if (pt.Y < leftBottom)
+                            {
+                                leftBottom = pt.Y;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        left = pt.X;
+                        leftBottom = leftTop = pt.Y;
+                    }
+                }
+
+                if (pt.Y >= top)
+                {
+                    if (pt.Y == top)
+                    {
+                        if (pt.X < topLeft)
+                        {
+                            topLeft = pt.X;
+                        }
+                        else
+                        {
+                            if (pt.X > topRight)
+                            {
+                                topRight = pt.X;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        top = pt.Y;
+                        topLeft = topRight = pt.X;
+                    }
+                }
+
+                if (pt.Y <= bottom)
+                {
+                    if (pt.Y == bottom)
+                    {
+                        if (pt.X < bottomLeft)
+                        {
+                            bottomLeft = pt.X;
+                        }
+                        else
+                        {
+                            if (pt.X > bottomRight)
+                            {
+                                bottomRight = pt.X;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        bottom = pt.Y;
+                        bottomRight = bottomLeft = pt.X;
+                    }
+                }
+
+                this._q1.FirstPoint = new MutablePoint(right, rightTop);
+                this._q1.LastPoint = new MutablePoint(topRight, top);
+                this._q1.RootPoint = new MutablePoint(topRight, rightTop);
+
+                this._q2.FirstPoint = new MutablePoint(topLeft, top);
+                this._q2.LastPoint = new MutablePoint(left, leftTop);
+                this._q2.RootPoint = new MutablePoint(topLeft, leftTop);
+
+                this._q3.FirstPoint = new MutablePoint(left, leftBottom);
+                this._q3.LastPoint = new MutablePoint(bottomLeft, bottom);
+                this._q3.RootPoint = new MutablePoint(bottomLeft, leftBottom);
+
+                this._q4.FirstPoint = new MutablePoint(bottomRight, bottom);
+                this._q4.LastPoint = new MutablePoint(right, rightBottom);
+                this._q4.RootPoint = new MutablePoint(bottomRight, rightBottom);
+
+            }
+        }
+
+        private Limit _limit = default(Limit);
+
+        /*
+        // ******************************************************************
+        // For usage of Parallel func, I highly suggest: Stephen Toub: Patterns of parallel programming ==> Just Awsome !!!
+        // But its only my own fault if I'm not using it at its full potential...
+        private void SetQuadrantLimitsUsingAllThreads()
+        {
+            MutablePoint pt = this._listOfPoint.First();
+            _limit = new Limit(pt);
+
+            int coreCount = Environment.ProcessorCount;
+
+            Task[] tasks = new Task[coreCount];
+            for (int n = 0; n < tasks.Length; n++)
+            {
+                int nLocal = n; // Prevent Lambda internal closure error.
+                tasks[n] = Task.Factory.StartNew(() =>
+                {
+                    Limit limit = _limit.Copy();
+                    FindLimits(_listOfPoint, nLocal, coreCount, limit);
+                    AggregateLimits(limit);
+                });
+            }
+            Task.WaitAll(tasks);
+
+            _q1.FirstPoint = _limit.Q1Right;
+            _q1.LastPoint = _limit.Q1Top;
+            _q2.FirstPoint = _limit.Q2Top;
+            _q2.LastPoint = _limit.Q2Left;
+            _q3.FirstPoint = _limit.Q3Left;
+            _q3.LastPoint = _limit.Q3Bottom;
+            _q4.FirstPoint = _limit.Q4Bottom;
+            _q4.LastPoint = _limit.Q4Right;
+
+            _q1.RootPoint = new MutablePoint(_q1.LastPoint.X, _q1.FirstPoint.Y);
+            _q2.RootPoint = new MutablePoint(_q2.FirstPoint.X, _q2.LastPoint.Y);
+            _q3.RootPoint = new MutablePoint(_q3.LastPoint.X, _q3.FirstPoint.Y);
+            _q4.RootPoint = new MutablePoint(_q4.FirstPoint.X, _q4.LastPoint.Y);
+        }
+        */
+
+        private Limit FindLimits(MutablePoint[] listOfPoint, int start, int offset, Limit limit)
+        {
+            for (int index = start; index < listOfPoint.Length; index += offset)
+            {
+                MutablePoint pt = listOfPoint[index];
+
+                double x = pt.X;
+                double y = pt.Y;
+
+                // Top
+                if (y >= limit.Q2Top.Y)
+                {
+                    if (y == limit.Q2Top.Y) // Special
+                    {
+                        if (y == limit.Q1Top.Y)
+                        {
+                            if (x < limit.Q2Top.X)
+                            {
+                                limit.Q2Top.X = x;
+                            }
+                            else if (x > limit.Q1Top.X)
+                            {
+                                limit.Q1Top.X = x;
+                            }
+                        }
+                        else
+                        {
+                            if (x < limit.Q2Top.X)
+                            {
+                                limit.Q1Top.X = limit.Q2Top.X;
+                                limit.Q1Top.Y = limit.Q2Top.Y;
+
+                                limit.Q2Top.X = x;
+                            }
+                            else if (x > limit.Q1Top.X)
+                            {
+                                limit.Q1Top.X = x;
+                                limit.Q1Top.Y = y;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        limit.Q2Top.X = x;
+                        limit.Q2Top.Y = y;
+                    }
+                }
+
+                // Bottom
+                if (y <= limit.Q3Bottom.Y)
+                {
+                    if (y == limit.Q3Bottom.Y) // Special
+                    {
+                        if (y == limit.Q4Bottom.Y)
+                        {
+                            if (x < limit.Q3Bottom.X)
+                            {
+                                limit.Q3Bottom.X = x;
+                            }
+                            else if (x > limit.Q4Bottom.X)
+                            {
+                                limit.Q4Bottom.X = x;
+                            }
+                        }
+                        else
+                        {
+                            if (x < limit.Q3Bottom.X)
+                            {
+                                limit.Q4Bottom.X = limit.Q3Bottom.X;
+                                limit.Q4Bottom.Y = limit.Q3Bottom.Y;
+
+                                limit.Q3Bottom.X = x;
+                            }
+                            else if (x > limit.Q3Bottom.X)
+                            {
+                                limit.Q4Bottom.X = x;
+                                limit.Q4Bottom.Y = y;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        limit.Q3Bottom.X = x;
+                        limit.Q3Bottom.Y = y;
+                    }
+                }
+
+                // Right
+                if (x >= limit.Q4Right.X)
+                {
+                    if (x == limit.Q4Right.X) // Special
+                    {
+                        if (x == limit.Q1Right.X)
+                        {
+                            if (y < limit.Q4Right.Y)
+                            {
+                                limit.Q4Right.Y = y;
+                            }
+                            else if (y > limit.Q1Right.Y)
+                            {
+                                limit.Q1Right.Y = y;
+                            }
+                        }
+                        else
+                        {
+                            if (y < limit.Q4Right.Y)
+                            {
+                                limit.Q1Right.X = limit.Q4Right.X;
+                                limit.Q1Right.Y = limit.Q4Right.Y;
+
+                                limit.Q4Right.Y = y;
+                            }
+                            else if (y > limit.Q1Right.Y)
+                            {
+                                limit.Q1Right.X = x;
+                                limit.Q1Right.Y = y;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        limit.Q4Right.X = x;
+                        limit.Q4Right.Y = y;
+                    }
+                }
+
+                // Left
+                if (x <= limit.Q3Left.X)
+                {
+                    if (x == limit.Q3Left.X) // Special
+                    {
+                        if (x == limit.Q2Left.X)
+                        {
+                            if (y < limit.Q3Left.Y)
+                            {
+                                limit.Q3Left.Y = y;
+                            }
+                            else if (y > limit.Q2Left.Y)
+                            {
+                                limit.Q2Left.Y = y;
+                            }
+                        }
+                        else
+                        {
+                            if (y < limit.Q3Left.Y)
+                            {
+                                limit.Q2Left.X = limit.Q3Left.X;
+                                limit.Q2Left.Y = limit.Q3Left.Y;
+
+                                limit.Q3Left.Y = y;
+                            }
+                            else if (y > limit.Q2Left.Y)
+                            {
+                                limit.Q2Left.X = x;
+                                limit.Q2Left.Y = y;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        limit.Q3Left.X = x;
+                        limit.Q3Left.Y = y;
+                    }
+                }
+
+                if (limit.Q2Left.X != limit.Q3Left.X)
+                {
+                    limit.Q2Left.X = limit.Q3Left.X;
+                    limit.Q2Left.Y = limit.Q3Left.Y;
+                }
+
+                if (limit.Q1Right.X != limit.Q4Right.X)
+                {
+                    limit.Q1Right.X = limit.Q4Right.X;
+                    limit.Q1Right.Y = limit.Q4Right.Y;
+                }
+
+                if (limit.Q1Top.Y != limit.Q2Top.Y)
+                {
+                    limit.Q1Top.X = limit.Q2Top.X;
+                    limit.Q1Top.Y = limit.Q2Top.Y;
+                }
+
+                if (limit.Q4Bottom.Y != limit.Q3Bottom.Y)
+                {
+                    limit.Q4Bottom.X = limit.Q3Bottom.X;
+                    limit.Q4Bottom.Y = limit.Q3Bottom.Y;
+                }
+            }
+
+            return limit;
+        }
+
+        private Limit FindLimits(MutablePoint pt, ParallelLoopState state, Limit limit)
+        {
+            double x = pt.X;
+            double y = pt.Y;
+
+            // Top
+            if (y >= limit.Q2Top.Y)
+            {
+                if (y == limit.Q2Top.Y) // Special
+                {
+                    if (y == limit.Q1Top.Y)
+                    {
+                        if (x < limit.Q2Top.X)
+                        {
+                            limit.Q2Top.X = x;
+                        }
+                        else if (x > limit.Q1Top.X)
+                        {
+                            limit.Q1Top.X = x;
+                        }
+                    }
+                    else
+                    {
+                        if (x < limit.Q2Top.X)
+                        {
+                            limit.Q1Top.X = limit.Q2Top.X;
+                            limit.Q1Top.Y = limit.Q2Top.Y;
+
+                            limit.Q2Top.X = x;
+                        }
+                        else if (x > limit.Q1Top.X)
+                        {
+                            limit.Q1Top.X = x;
+                            limit.Q1Top.Y = y;
+                        }
+                    }
+                }
+                else
+                {
+                    limit.Q2Top.X = x;
+                    limit.Q2Top.Y = y;
+                }
+            }
+
+            // Bottom
+            if (y <= limit.Q3Bottom.Y)
+            {
+                if (y == limit.Q3Bottom.Y) // Special
+                {
+                    if (y == limit.Q4Bottom.Y)
+                    {
+                        if (x < limit.Q3Bottom.X)
+                        {
+                            limit.Q3Bottom.X = x;
+                        }
+                        else if (x > limit.Q4Bottom.X)
+                        {
+                            limit.Q4Bottom.X = x;
+                        }
+                    }
+                    else
+                    {
+                        if (x < limit.Q3Bottom.X)
+                        {
+                            limit.Q4Bottom.X = limit.Q3Bottom.X;
+                            limit.Q4Bottom.Y = limit.Q3Bottom.Y;
+
+                            limit.Q3Bottom.X = x;
+                        }
+                        else if (x > limit.Q3Bottom.X)
+                        {
+                            limit.Q4Bottom.X = x;
+                            limit.Q4Bottom.Y = y;
+                        }
+                    }
+                }
+                else
+                {
+                    limit.Q3Bottom.X = x;
+                    limit.Q3Bottom.Y = y;
+                }
+            }
+
+            // Right
+            if (x >= limit.Q4Right.X)
+            {
+                if (x == limit.Q4Right.X) // Special
+                {
+                    if (x == limit.Q1Right.X)
+                    {
+                        if (y < limit.Q4Right.Y)
+                        {
+                            limit.Q4Right.Y = y;
+                        }
+                        else if (y > limit.Q1Right.Y)
+                        {
+                            limit.Q1Right.Y = y;
+                        }
+                    }
+                    else
+                    {
+                        if (y < limit.Q4Right.Y)
+                        {
+                            limit.Q1Right.X = limit.Q4Right.X;
+                            limit.Q1Right.Y = limit.Q4Right.Y;
+
+                            limit.Q4Right.Y = y;
+                        }
+                        else if (y > limit.Q1Right.Y)
+                        {
+                            limit.Q1Right.X = x;
+                            limit.Q1Right.Y = y;
+                        }
+                    }
+                }
+                else
+                {
+                    limit.Q4Right.X = x;
+                    limit.Q4Right.Y = y;
+                }
+            }
+
+            // Left
+            if (x <= limit.Q3Left.X)
+            {
+                if (x == limit.Q3Left.X) // Special
+                {
+                    if (x == limit.Q2Left.X)
+                    {
+                        if (y < limit.Q3Left.Y)
+                        {
+                            limit.Q3Left.Y = y;
+                        }
+                        else if (y > limit.Q2Left.Y)
+                        {
+                            limit.Q2Left.Y = y;
+                        }
+                    }
+                    else
+                    {
+                        if (y < limit.Q3Left.Y)
+                        {
+                            limit.Q2Left.X = limit.Q3Left.X;
+                            limit.Q2Left.Y = limit.Q3Left.Y;
+
+                            limit.Q3Left.Y = y;
+                        }
+                        else if (y > limit.Q2Left.Y)
+                        {
+                            limit.Q2Left.X = x;
+                            limit.Q2Left.Y = y;
+                        }
+                    }
+                }
+                else
+                {
+                    limit.Q3Left.X = x;
+                    limit.Q3Left.Y = y;
+                }
+            }
+
+            if (limit.Q2Left.X != limit.Q3Left.X)
+            {
+                limit.Q2Left.X = limit.Q3Left.X;
+                limit.Q2Left.Y = limit.Q3Left.Y;
+            }
+
+            if (limit.Q1Right.X != limit.Q4Right.X)
+            {
+                limit.Q1Right.X = limit.Q4Right.X;
+                limit.Q1Right.Y = limit.Q4Right.Y;
+            }
+
+            if (limit.Q1Top.Y != limit.Q2Top.Y)
+            {
+                limit.Q1Top.X = limit.Q2Top.X;
+                limit.Q1Top.Y = limit.Q2Top.Y;
+            }
+
+            if (limit.Q4Bottom.Y != limit.Q3Bottom.Y)
+            {
+                limit.Q4Bottom.X = limit.Q3Bottom.X;
+                limit.Q4Bottom.Y = limit.Q3Bottom.Y;
+            }
+
+            return limit;
+        }
+
+        private object _findLimitFinalLock = new object();
+
+        private void AggregateLimits(Limit limit)
+        {
+            lock (_findLimitFinalLock)
+            {
+                if (limit.Q1Right.X >= _limit.Q1Right.X)
+                {
+                    if (limit.Q1Right.X == _limit.Q1Right.X)
+                    {
+                        if (limit.Q1Right.Y > _limit.Q1Right.Y)
+                        {
+                            _limit.Q1Right = limit.Q1Right;
+                        }
+                    }
+                    else
+                    {
+                        _limit.Q1Right = limit.Q1Right;
+                    }
+                }
+
+                if (limit.Q4Right.X > _limit.Q4Right.X)
+                {
+                    if (limit.Q4Right.X == _limit.Q4Right.X)
+                    {
+                        if (limit.Q4Right.Y < _limit.Q4Right.Y)
+                        {
+                            _limit.Q4Right = limit.Q4Right;
+                        }
+                    }
+                    else
+                    {
+                        _limit.Q4Right = limit.Q4Right;
+                    }
+                }
+
+                if (limit.Q2Left.X < _limit.Q2Left.X)
+                {
+                    if (limit.Q2Left.X == _limit.Q2Left.X)
+                    {
+                        if (limit.Q2Left.Y > _limit.Q2Left.Y)
+                        {
+                            _limit.Q2Left = limit.Q2Left;
+                        }
+                    }
+                    else
+                    {
+                        _limit.Q2Left = limit.Q2Left;
+                    }
+                }
+
+                if (limit.Q3Left.X < _limit.Q3Left.X)
+                {
+                    if (limit.Q3Left.X == _limit.Q3Left.X)
+                    {
+                        if (limit.Q3Left.Y > _limit.Q3Left.Y)
+                        {
+                            _limit.Q3Left = limit.Q3Left;
+                        }
+                    }
+                    else
+                    {
+                        _limit.Q3Left = limit.Q3Left;
+                    }
+                }
+
+                if (limit.Q1Top.Y > _limit.Q1Top.Y)
+                {
+                    if (limit.Q1Top.Y == _limit.Q1Top.Y)
+                    {
+                        if (limit.Q1Top.X > _limit.Q1Top.X)
+                        {
+                            _limit.Q1Top = limit.Q1Top;
+                        }
+                    }
+                    else
+                    {
+                        _limit.Q1Top = limit.Q1Top;
+                    }
+                }
+
+                if (limit.Q2Top.Y > _limit.Q2Top.Y)
+                {
+                    if (limit.Q2Top.Y == _limit.Q2Top.Y)
+                    {
+                        if (limit.Q2Top.X < _limit.Q2Top.X)
+                        {
+                            _limit.Q2Top = limit.Q2Top;
+                        }
+                    }
+                    else
+                    {
+                        _limit.Q2Top = limit.Q2Top;
+                    }
+                }
+
+                if (limit.Q3Bottom.Y < _limit.Q3Bottom.Y)
+                {
+                    if (limit.Q3Bottom.Y == _limit.Q3Bottom.Y)
+                    {
+                        if (limit.Q3Bottom.X < _limit.Q3Bottom.X)
+                        {
+                            _limit.Q3Bottom = limit.Q3Bottom;
+                        }
+                    }
+                    else
+                    {
+                        _limit.Q3Bottom = limit.Q3Bottom;
+                    }
+                }
+
+                if (limit.Q4Bottom.Y < _limit.Q4Bottom.Y)
+                {
+                    if (limit.Q4Bottom.Y == _limit.Q4Bottom.Y)
+                    {
+                        if (limit.Q4Bottom.X > _limit.Q4Bottom.X)
+                        {
+                            _limit.Q4Bottom = limit.Q4Bottom;
+                        }
+                    }
+                    else
+                    {
+                        _limit.Q4Bottom = limit.Q4Bottom;
+                    }
+                }
+            }
+        }
+
+        public Point2D[] GetResultsAsArrayOfPoint()
+        {
+            if (_listOfPoint == null || !_listOfPoint.Any())
+            {
+                return new Point2D[0];
+            }
+
+            int countOfPoints = _q1.Count + _q2.Count + _q3.Count + _q4.Count;
+
+            if (_q1.LastPoint == _q2.FirstPoint)
+            {
+                countOfPoints--;
+            }
+
+            if (_q2.LastPoint == _q3.FirstPoint)
+            {
+                countOfPoints--;
+            }
+
+            if (_q3.LastPoint == _q4.FirstPoint)
+            {
+                countOfPoints--;
+            }
+
+            if (_q4.LastPoint == _q1.FirstPoint)
+            {
+                countOfPoints--;
+            }
+
+            if (countOfPoints == 0) // Case where there is only one point
+            {
+                return new Point2D[] { new Point2D(_q1.FirstPoint.X, _q1.FirstPoint.Y) };
+            }
+
+            if (_shouldCloseTheGraph)
+            {
+                countOfPoints++;
+            }
+
+            Point2D[] results = new Point2D[countOfPoints];
+
+            int resultIndex = -1;
+
+            if (_q1.FirstPoint != _q4.LastPoint)
+            {
+                foreach (MutablePoint pt in _q1)
+                {
+                    results[++resultIndex] = new Point2D(pt.X, pt.Y);
+                }
+            }
+            else
+            {
+                var enumerator = _q1.GetEnumerator();
+                enumerator.Reset();
+                if (enumerator.MoveNext())
+                {
+                    // Skip first (same as the last one as quadrant 4
+
+                    while (enumerator.MoveNext())
+                    {
+                        results[++resultIndex] = new Point2D(enumerator.Current.X, enumerator.Current.Y);
+                    }
+                }
+            }
+
+            if (_q2.Count == 1)
+            {
+                if (_q2.FirstPoint != _q1.LastPoint)
+                {
+                    results[++resultIndex] = new Point2D(_q2.FirstPoint.X, _q2.FirstPoint.Y);
+                }
+            }
+            else
+            {
+                var enumerator = _q2.GetEnumerator();
+                enumerator.Reset();
+                if (enumerator.MoveNext()) // Will always be true
+                {
+                    if (enumerator.Current != _q1.LastPoint)
+                    {
+                        results[++resultIndex] = new Point2D(enumerator.Current.X, enumerator.Current.Y);
+                    }
+
+                    while (enumerator.MoveNext())
+                    {
+                        results[++resultIndex] = new Point2D(enumerator.Current.X, enumerator.Current.Y);
+                    }
+                }
+            }
+
+            if (_q3.Count == 1)
+            {
+                if (_q3.FirstPoint != _q2.LastPoint)
+                {
+                    results[++resultIndex] = new Point2D(_q3.FirstPoint.X, _q3.FirstPoint.Y);
+                }
+            }
+            else
+            {
+                var enumerator = _q3.GetEnumerator();
+                enumerator.Reset();
+                if (enumerator.MoveNext()) // Will always be true
+                {
+                    if (enumerator.Current != _q2.LastPoint)
+                    {
+                        results[++resultIndex] = new Point2D(enumerator.Current.X, enumerator.Current.Y);
+                    }
+
+                    while (enumerator.MoveNext())
+                    {
+                        results[++resultIndex] = new Point2D(enumerator.Current.X, enumerator.Current.Y);
+                    }
+                }
+            }
+
+            if (_q4.Count == 1)
+            {
+                if (_q4.FirstPoint != _q3.LastPoint)
+                {
+                    results[++resultIndex] = new Point2D(_q4.FirstPoint.X, _q4.FirstPoint.Y);
+                }
+            }
+            else
+            {
+                var enumerator = _q4.GetEnumerator();
+                enumerator.Reset();
+                if (enumerator.MoveNext()) // Will always be true
+                {
+                    if (enumerator.Current != _q3.LastPoint)
+                    {
+                        results[++resultIndex] = new Point2D(enumerator.Current.X, enumerator.Current.Y);
+                    }
+
+                    while (enumerator.MoveNext())
+                    {
+                        results[++resultIndex] = new Point2D(enumerator.Current.X, enumerator.Current.Y);
+                    }
+                }
+            }
+
+            if (_shouldCloseTheGraph && results[resultIndex] != results[0])
+            {
+                results[++resultIndex] = results[0];
+            }
+
+            return results;
+
+        }
+
+        private bool IsZeroData()
+        {
+            return _listOfPoint == null || !_listOfPoint.Any();
+        }
+    }
+}

--- a/src/Spatial/Internals/ConvexHull/MutablePoint.cs
+++ b/src/Spatial/Internals/ConvexHull/MutablePoint.cs
@@ -1,0 +1,26 @@
+﻿namespace MathNet.Spatial.Internals
+{
+    using System;
+
+    internal struct MutablePoint : IEquatable<MutablePoint>
+    {
+        internal MutablePoint(double x, double y)
+        {
+            this.X = x;
+            this.Y = y;
+        }
+
+        internal double X { get; set; }
+
+        internal double Y { get; set; }
+
+        public static bool operator ==(MutablePoint p1, MutablePoint p2) => p1.Equals(p2);
+
+        public static bool operator !=(MutablePoint p1, MutablePoint p2) => !p1.Equals(p2);
+
+        public bool Equals(MutablePoint other)
+        {
+            return this.X == other.X && this.Y == other.Y;
+        }
+    }
+}

--- a/src/Spatial/Internals/ConvexHull/QComparer.cs
+++ b/src/Spatial/Internals/ConvexHull/QComparer.cs
@@ -14,7 +14,7 @@
 
         public int Compare(MutablePoint pt1, MutablePoint pt2)
         {
-            return this.comparer.Invoke(pt1, pt2);
+            return this.comparer(pt1, pt2);
         }
     }
 }

--- a/src/Spatial/Internals/ConvexHull/QComparer.cs
+++ b/src/Spatial/Internals/ConvexHull/QComparer.cs
@@ -1,0 +1,20 @@
+﻿namespace MathNet.Spatial.Internals
+{
+    using System;
+    using System.Collections.Generic;
+
+    internal class QComparer : IComparer<MutablePoint>
+    {
+        private Func<MutablePoint, MutablePoint, int> comparer;
+
+        public QComparer(Func<MutablePoint, MutablePoint, int> comparer)
+        {
+            this.comparer = comparer;
+        }
+
+        public int Compare(MutablePoint pt1, MutablePoint pt2)
+        {
+            return this.comparer.Invoke(pt1, pt2);
+        }
+    }
+}

--- a/src/Spatial/Internals/ConvexHull/Quadrant.cs
+++ b/src/Spatial/Internals/ConvexHull/Quadrant.cs
@@ -1,0 +1,142 @@
+﻿namespace MathNet.Spatial.Internals
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    internal abstract class Quadrant : AvlTreeSet<MutablePoint>
+    {
+        internal enum Side
+        {
+            Unknown = 0,
+            Left = 1,
+            Right = 2
+        }
+
+        public MutablePoint FirstPoint;
+        public MutablePoint LastPoint;
+        public MutablePoint RootPoint;
+
+        protected AvlNode<MutablePoint> CurrentNode = null;
+
+        protected MutablePoint[] ListOfPoint;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Quadrant"/> class.
+        /// </summary>
+        /// <param name="listOfPoint"></param>
+        /// <param name="comparer">Comparer is only used to add the second point (the last point, which is compared against the first one).</param>
+        internal Quadrant(MutablePoint[] listOfPoint, IComparer<MutablePoint> comparer)
+            : base(comparer)
+        {
+            ListOfPoint = listOfPoint;
+        }
+
+        /// <summary>
+        /// Initialize every values needed to extract values that are parts of the convex hull.
+        /// This is where the first pass of all values is done the get maximum in every directions (x and y).
+        /// </summary>
+        protected abstract void SetQuadrantLimits();
+
+        public void Prepare()
+        {
+            if (!ListOfPoint.Any())
+            {
+                // There is no points at all. Hey don't try to crash me.
+                return;
+            }
+
+            // Begin : General Init
+            Add(FirstPoint);
+            if (FirstPoint.Equals(LastPoint))
+            {
+                return; // Case where for weird distribution like triangle or diagonal. This quadrant will have no point
+            }
+
+            Add(LastPoint);
+        }
+
+        /// <summary>
+        /// To know if to the right. It is meaninful when p1 is first and p2 is next.
+        /// </summary>
+        /// <param name="p1"></param>
+        /// <param name="p2"></param>
+        /// <param name="ptToCheck"></param>
+        /// <returns>Equivalent of tracing a line from p1 to p2 and tell if ptToCheck
+        ///  is to the right or left of that line taking p1 as reference point.</returns>
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected bool IsPointToTheRightOfOthers(MutablePoint p1, MutablePoint p2, MutablePoint ptToCheck)
+        {
+            return ((p2.X - p1.X) * (ptToCheck.Y - p1.Y)) - ((p2.Y - p1.Y) * (ptToCheck.X - p1.X)) < 0;
+        }
+
+        /// <summary>
+        /// Tell if should try to add and where. -1 ==> Should not add.
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns></returns>
+        internal abstract void ProcessPoint(ref MutablePoint point);
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected abstract bool IsGoodQuadrantForPoint(MutablePoint pt);
+
+        // protected abstract bool CanQuickReject(Point pt, Point ptHull);
+        
+        /// <summary>
+        /// Called after insertion in order to see if the newly added point invalidate one 
+        /// or more neighbors and if so, remove it/them from the tree.
+        /// </summary>
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void InvalidateNeighbors(AvlNode<MutablePoint> pointPrevious, AvlNode<MutablePoint> pointNew, AvlNode<MutablePoint> pointNext)
+        {
+            bool invalidPoint;
+
+            if (pointPrevious != null)
+            {
+                AvlNode<MutablePoint> previousPrevious = pointPrevious.GetPreviousNode();
+                for (;;)
+                {
+                    if (previousPrevious == null)
+                    {
+                        break;
+                    }
+
+                    invalidPoint = !IsPointToTheRightOfOthers(previousPrevious.Item, pointNew.Item, pointPrevious.Item);
+                    if (!invalidPoint)
+                    {
+                        break;
+                    }
+
+                    MutablePoint ptPrevPrev = previousPrevious.Item;
+                    RemoveNode(pointPrevious);
+                    pointPrevious = this.GetNode(ptPrevPrev);
+                    previousPrevious = pointPrevious.GetPreviousNode();
+                }
+            }
+
+            // Invalidate next(s)
+            if (pointNext != null)
+            {
+                AvlNode<MutablePoint> nextNext = pointNext.GetNextNode();
+                for (; ;)
+                {
+                    if (nextNext == null)
+                    {
+                        break;
+                    }
+
+                    invalidPoint = !IsPointToTheRightOfOthers(pointNew.Item, nextNext.Item, pointNext.Item);
+                    if (!invalidPoint)
+                    {
+                        break;
+                    }
+
+                    MutablePoint ptNextNext = nextNext.Item;
+                    RemoveNode(pointNext);
+                    pointNext = GetNode(ptNextNext);
+                    nextNext = pointNext.GetNextNode();
+                }
+            }
+        }
+    }
+}

--- a/src/Spatial/Internals/ConvexHull/QuadrantSpecific1.cs
+++ b/src/Spatial/Internals/ConvexHull/QuadrantSpecific1.cs
@@ -1,0 +1,224 @@
+﻿namespace MathNet.Spatial.Internals
+{
+    using System;
+    using System.Linq;
+
+    internal class QuadrantSpecific1 : Quadrant
+    {
+        internal QuadrantSpecific1(MutablePoint[] listOfPoint, Func<MutablePoint, MutablePoint, int> comparer)
+            : base(listOfPoint, new QComparer(comparer))
+        {
+        }
+
+        protected override void SetQuadrantLimits()
+        {
+            MutablePoint firstPoint = this.ListOfPoint.First();
+
+            double rightX = firstPoint.X;
+            double rightY = firstPoint.Y;
+
+            double topX = rightX;
+            double topY = rightY;
+
+            foreach (var point in ListOfPoint)
+            {
+                if (point.X >= rightX)
+                {
+                    if (point.X == rightX)
+                    {
+                        if (point.Y > rightY)
+                        {
+                            rightY = point.Y;
+                        }
+                    }
+                    else
+                    {
+                        rightX = point.X;
+                        rightY = point.Y;
+                    }
+                }
+
+                if (point.Y >= topY)
+                {
+                    if (point.Y == topY)
+                    {
+                        if (point.X > topX)
+                        {
+                            topX = point.X;
+                        }
+                    }
+                    else
+                    {
+                        topX = point.X;
+                        topY = point.Y;
+                    }
+                }
+            }
+
+            FirstPoint = new MutablePoint(rightX, rightY);
+            LastPoint = new MutablePoint(topX, topY);
+            RootPoint = new MutablePoint(topX, rightY);
+        }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override bool IsGoodQuadrantForPoint(MutablePoint pt)
+        {
+            if (pt.X > this.RootPoint.X && pt.Y > this.RootPoint.Y)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Iterate over each points to see if we can add it has a ConvexHull point.
+        /// It is specific by Quadrant to improve efficiency.
+        /// </summary>
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override void ProcessPoint(ref MutablePoint point)
+        {
+            CurrentNode = Root;
+            AvlNode<MutablePoint> currentPrevious = null;
+            AvlNode<MutablePoint> currentNext = null;
+
+            while (CurrentNode != null)
+            {
+                //if (CanQuickReject(point, CurrentNode.Item))
+                //{
+                //	return false;
+                //}
+
+                var insertionSide = Side.Unknown;
+                if (point.X > CurrentNode.Item.X)
+                {
+                    if (CurrentNode.Left != null)
+                    {
+                        CurrentNode = CurrentNode.Left;
+                        continue;
+                    }
+
+                    currentPrevious = CurrentNode.GetPreviousNode();
+                    if (CanQuickReject(ref point, ref currentPrevious.Item))
+                    {
+                        return;
+                    }
+
+                    if (!IsPointToTheRightOfOthers(currentPrevious.Item, CurrentNode.Item, point))
+                    {
+                        return;
+                    }
+
+                    if (CurrentNode.Item == point) // Ensure to have no duplicate
+                    {
+                        return;
+                    }
+
+                    insertionSide = Side.Left;
+                }
+                else if (point.X < CurrentNode.Item.X)
+                {
+                    if (CurrentNode.Right != null)
+                    {
+                        CurrentNode = CurrentNode.Right;
+                        continue;
+                    }
+
+                    currentNext = CurrentNode.GetNextNode();
+                    if (CanQuickReject(ref point, ref currentNext.Item))
+                    {
+                        return;
+                    }
+
+                    if (!IsPointToTheRightOfOthers(CurrentNode.Item, currentNext.Item, point))
+                    {
+                        return;
+                    }
+
+                    if (CurrentNode.Item == point) // Ensure to have no duplicate
+                    {
+                        return;
+                    }
+
+                    insertionSide = Side.Right;
+                }
+                else
+                {
+                    if (point.Y <= CurrentNode.Item.Y)
+                    {
+                        return; // invalid point
+                    }
+
+                    // Replace CurrentNode point with point
+                    CurrentNode.Item = point;
+
+                    InvalidateNeighbors(CurrentNode.GetPreviousNode(), CurrentNode, CurrentNode.GetNextNode());
+                    return;
+                }
+
+                //We should insert the point
+
+                // Try to optimize and verify if can replace a node instead insertion to minimize tree balancing
+                if (insertionSide == Side.Right)
+                {
+                    currentPrevious = CurrentNode.GetPreviousNode();
+                    if (currentPrevious != null && !IsPointToTheRightOfOthers(currentPrevious.Item, point, CurrentNode.Item))
+                    {
+                        CurrentNode.Item = point;
+                        InvalidateNeighbors(currentPrevious, CurrentNode, currentNext);
+                        return;
+                    }
+
+                    var nextNext = currentNext.GetNextNode();
+                    if (nextNext != null && !IsPointToTheRightOfOthers(point, nextNext.Item, currentNext.Item))
+                    {
+                        currentNext.Item = point;
+                        InvalidateNeighbors(null, currentNext, nextNext);
+                        return;
+                    }
+                }
+                else // Left
+                {
+                    currentNext = CurrentNode.GetNextNode();
+                    if (currentNext != null && !IsPointToTheRightOfOthers(point, currentNext.Item, CurrentNode.Item))
+                    {
+                        CurrentNode.Item = point;
+                        InvalidateNeighbors(currentPrevious, CurrentNode, currentNext);
+                        return;
+                    }
+
+                    var previousPrevious = currentPrevious.GetPreviousNode();
+                    if (previousPrevious != null && !IsPointToTheRightOfOthers(previousPrevious.Item, point, currentPrevious.Item))
+                    {
+                        currentPrevious.Item = point;
+                        InvalidateNeighbors(previousPrevious, currentPrevious, null);
+                        return;
+                    }
+                }
+
+                // Should insert but no invalidation is required. (That's why we need to insert... can't replace an adjacent neightbor)
+                AvlNode<MutablePoint> newNode = new AvlNode<MutablePoint>();
+                if (insertionSide == Side.Right)
+                {
+                    newNode.Parent = CurrentNode;
+                    newNode.Item = point;
+                    CurrentNode.Right = newNode;
+                    this.AddBalance(newNode.Parent, -1);
+                }
+                else // Left
+                {
+                    newNode.Parent = CurrentNode;
+                    newNode.Item = point;
+                    CurrentNode.Left = newNode;
+                    this.AddBalance(newNode.Parent, 1);
+                }
+            }
+        }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool CanQuickReject(ref MutablePoint pt, ref MutablePoint ptHull)
+        {
+            return pt.X <= ptHull.X && pt.Y <= ptHull.Y;
+        }
+    }
+}

--- a/src/Spatial/Internals/ConvexHull/QuadrantSpecific2.cs
+++ b/src/Spatial/Internals/ConvexHull/QuadrantSpecific2.cs
@@ -1,0 +1,226 @@
+﻿namespace MathNet.Spatial.Internals
+{
+    using System;
+    using System.Linq;
+
+    internal class QuadrantSpecific2 : Quadrant
+    {
+        internal QuadrantSpecific2(MutablePoint[] listOfPoint, Func<MutablePoint, MutablePoint, int> comparer)
+            : base(listOfPoint, new QComparer(comparer))
+        {
+        }
+
+        protected override void SetQuadrantLimits()
+        {
+            MutablePoint firstPoint = this.ListOfPoint.First();
+
+            double leftX = firstPoint.X;
+            double leftY = firstPoint.Y;
+
+            double topX = leftX;
+            double topY = leftY;
+
+            foreach (var point in ListOfPoint)
+            {
+
+                if (point.X <= leftX)
+                {
+                    if (point.X == leftX)
+                    {
+                        if (point.Y > leftY)
+                        {
+                            leftY = point.Y;
+                        }
+                    }
+                    else
+                    {
+                        leftX = point.X;
+                        leftY = point.Y;
+                    }
+                }
+
+                if (point.Y >= topY)
+                {
+                    if (point.Y == topY)
+                    {
+                        if (point.X < topX)
+                        {
+                            topX = point.X;
+                        }
+                    }
+                    else
+                    {
+                        topX = point.X;
+                        topY = point.Y;
+                    }
+                }
+            }
+
+            FirstPoint = new MutablePoint(topX, topY);
+            LastPoint = new MutablePoint(leftX, leftY);
+            RootPoint = new MutablePoint(topX, leftY);
+        }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override bool IsGoodQuadrantForPoint(MutablePoint pt)
+        {
+            if (pt.X < this.RootPoint.X && pt.Y > this.RootPoint.Y)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Iterate over each points to see if we can add it has a ConvexHull point.
+        /// It is specific by Quadrant to improve efficiency.
+        /// </summary>
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override void ProcessPoint(ref MutablePoint point)
+        {
+            CurrentNode = Root;
+            AvlNode<MutablePoint> currentPrevious = null;
+            AvlNode<MutablePoint> currentNext = null;
+
+            while (CurrentNode != null)
+            {
+                //if (CanQuickReject(point, CurrentNode.Item))
+                //{
+                //	return false;
+                //}
+
+                var insertionSide = Side.Unknown;
+                if (point.X > CurrentNode.Item.X)
+                {
+                    if (CurrentNode.Left != null)
+                    {
+                        CurrentNode = CurrentNode.Left;
+                        continue;
+                    }
+
+                    currentPrevious = CurrentNode.GetPreviousNode();
+                    if (CanQuickReject(ref point, ref currentPrevious.Item))
+                    {
+                        return;
+                    }
+
+                    if (!IsPointToTheRightOfOthers(currentPrevious.Item, CurrentNode.Item, point))
+                    {
+                        return;
+                    }
+
+                    if (CurrentNode.Item == point) // Ensure to have no duplicate
+                    {
+                        return;
+                    }
+
+                    insertionSide = Side.Left;
+                }
+                else if (point.X < CurrentNode.Item.X)
+                {
+                    if (CurrentNode.Right != null)
+                    {
+                        CurrentNode = CurrentNode.Right;
+                        continue;
+                    }
+
+                    currentNext = CurrentNode.GetNextNode();
+                    if (CanQuickReject(ref point, ref currentNext.Item))
+                    {
+                        return;
+                    }
+
+                    if (!IsPointToTheRightOfOthers(CurrentNode.Item, currentNext.Item, point))
+                    {
+                        return;
+                    }
+
+                    if (CurrentNode.Item == point) // Ensure to have no duplicate
+                    {
+                        continue;
+                    }
+
+                    insertionSide = Side.Right;
+                }
+                else
+                {
+                    if (point.Y <= CurrentNode.Item.Y)
+                    {
+                        return; // invalid point
+                    }
+
+                    // Replace CurrentNode point with point
+                    CurrentNode.Item = point;
+                    InvalidateNeighbors(CurrentNode.GetPreviousNode(), CurrentNode, CurrentNode.GetNextNode());
+                    return;
+                }
+
+                //We should insert the point
+
+                // Try to optimize and verify if can replace a node instead insertion to minimize tree balancing
+                if (insertionSide == Side.Right)
+                {
+                    currentPrevious = CurrentNode.GetPreviousNode();
+                    if (currentPrevious != null && !IsPointToTheRightOfOthers(currentPrevious.Item, point, CurrentNode.Item))
+                    {
+                        CurrentNode.Item = point;
+                        InvalidateNeighbors(currentPrevious, CurrentNode, currentNext);
+                        return;
+                    }
+
+                    var nextNext = currentNext.GetNextNode();
+                    if (nextNext != null && !IsPointToTheRightOfOthers(point, nextNext.Item, currentNext.Item))
+                    {
+                        currentNext.Item = point;
+                        InvalidateNeighbors(null, currentNext, nextNext);
+                        return;
+                    }
+                }
+                else // Left
+                {
+                    currentNext = CurrentNode.GetNextNode();
+                    if (currentNext != null && !IsPointToTheRightOfOthers(point, currentNext.Item, CurrentNode.Item))
+                    {
+                        CurrentNode.Item = point;
+                        InvalidateNeighbors(currentPrevious, CurrentNode, currentNext);
+                        return;
+                    }
+
+                    var previousPrevious = currentPrevious.GetPreviousNode();
+                    if (previousPrevious != null && !IsPointToTheRightOfOthers(previousPrevious.Item, point, currentPrevious.Item))
+                    {
+                        currentPrevious.Item = point;
+                        InvalidateNeighbors(previousPrevious, currentPrevious, null);
+                        return;
+                    }
+                }
+
+                // Should insert but no invalidation is required. (That's why we need to insert... can't replace an adjacent neightbor)
+                AvlNode<MutablePoint> newNode = new AvlNode<MutablePoint>();
+                if (insertionSide == Side.Right)
+                {
+                    newNode.Parent = CurrentNode;
+                    newNode.Item = point;
+                    CurrentNode.Right = newNode;
+                    this.AddBalance(newNode.Parent, -1);
+                }
+                else // Left
+                {
+                    newNode.Parent = CurrentNode;
+                    newNode.Item = point;
+                    CurrentNode.Left = newNode;
+                    this.AddBalance(newNode.Parent, 1);
+                }
+
+                return;
+            }
+        }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool CanQuickReject(ref MutablePoint pt, ref MutablePoint ptHull)
+        {
+            return pt.X >= ptHull.X && pt.Y <= ptHull.Y;
+        }
+    }
+}

--- a/src/Spatial/Internals/ConvexHull/QuadrantSpecific3.cs
+++ b/src/Spatial/Internals/ConvexHull/QuadrantSpecific3.cs
@@ -1,0 +1,226 @@
+﻿namespace MathNet.Spatial.Internals
+{
+    using System;
+    using System.Linq;
+
+    internal class QuadrantSpecific3 : Quadrant
+    {
+        internal QuadrantSpecific3(MutablePoint[] listOfPoint, Func<MutablePoint, MutablePoint, int> comparer)
+            : base(listOfPoint, new QComparer(comparer))
+        {
+        }
+
+        protected override void SetQuadrantLimits()
+        {
+            MutablePoint firstPoint = this.ListOfPoint.First();
+
+            double leftX = firstPoint.X;
+            double leftY = firstPoint.Y;
+
+            double bottomX = leftX;
+            double bottomY = leftY;
+
+            foreach (var point in ListOfPoint)
+            {
+                if (point.X <= leftX)
+                {
+                    if (point.X == leftX)
+                    {
+                        if (point.Y < leftY)
+                        {
+                            leftY = point.Y;
+                        }
+                    }
+                    else
+                    {
+                        leftX = point.X;
+                        leftY = point.Y;
+                    }
+                }
+
+                if (point.Y <= bottomY)
+                {
+                    if (point.Y == bottomY)
+                    {
+                        if (point.X < bottomX)
+                        {
+                            bottomX = point.X;
+                        }
+                    }
+                    else
+                    {
+                        bottomX = point.X;
+                        bottomY = point.Y;
+                    }
+                }
+            }
+
+            FirstPoint = new MutablePoint(leftX, leftY);
+            LastPoint = new MutablePoint(bottomX, bottomY);
+            RootPoint = new MutablePoint(bottomX, leftY);
+        }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override bool IsGoodQuadrantForPoint(MutablePoint pt)
+        {
+            if (pt.X < this.RootPoint.X && pt.Y < this.RootPoint.Y)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Iterate over each points to see if we can add it has a ConvexHull point.
+        /// It is specific by Quadrant to improve efficiency.
+        /// </summary>
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override void ProcessPoint(ref MutablePoint point)
+        {
+            CurrentNode = Root;
+            AvlNode<MutablePoint> currentPrevious = null;
+            AvlNode<MutablePoint> currentNext = null;
+
+            while (CurrentNode != null)
+            {
+                //if (CanQuickReject(point, CurrentNode.Item))
+                //{
+                //	return false;
+                //}
+
+                var insertionSide = Side.Unknown;
+                if (point.X > CurrentNode.Item.X)
+                {
+                    if (CurrentNode.Right != null)
+                    {
+                        CurrentNode = CurrentNode.Right;
+                        continue;
+                    }
+                    currentNext = CurrentNode.GetNextNode();
+                    if (CanQuickReject(ref point, ref currentNext.Item))
+                    {
+                        return;
+                    }
+
+                    if (!IsPointToTheRightOfOthers(CurrentNode.Item, currentNext.Item, point))
+                    {
+                        return;
+                    }
+
+                    if (CurrentNode.Item == point) // Ensure to have no duplicate
+                    {
+                        continue;
+                    }
+
+                    insertionSide = Side.Right;
+                }
+                else if (point.X < CurrentNode.Item.X)
+                {
+                    if (CurrentNode.Left != null)
+                    {
+                        CurrentNode = CurrentNode.Left;
+                        continue;
+                    }
+
+                    currentPrevious = CurrentNode.GetPreviousNode();
+                    if (CanQuickReject(ref point, ref currentPrevious.Item))
+                    {
+                        return;
+                    }
+
+                    if (!IsPointToTheRightOfOthers(currentPrevious.Item, CurrentNode.Item, point))
+                    {
+                        return;
+                    }
+
+                    if (CurrentNode.Item == point) // Ensure to have no duplicate
+                    {
+                        return;
+                    }
+
+                    insertionSide = Side.Left;
+                }
+                else
+                {
+                    if (point.Y >= CurrentNode.Item.Y)
+                    {
+                        return; // invalid point
+                    }
+
+                    // Replace CurrentNode point with point
+                    CurrentNode.Item = point;
+                    InvalidateNeighbors(CurrentNode.GetPreviousNode(), CurrentNode, CurrentNode.GetNextNode());
+                    return;
+                }
+
+                //We should insert the point
+
+                // Try to optimize and verify if can replace a node instead insertion to minimize tree balancing
+                if (insertionSide == Side.Right)
+                {
+                    currentPrevious = CurrentNode.GetPreviousNode();
+                    if (currentPrevious != null && !IsPointToTheRightOfOthers(currentPrevious.Item, point, CurrentNode.Item))
+                    {
+                        CurrentNode.Item = point;
+                        InvalidateNeighbors(currentPrevious, CurrentNode, currentNext);
+                        return;
+                    }
+
+                    var nextNext = currentNext.GetNextNode();
+                    if (nextNext != null && !IsPointToTheRightOfOthers(point, nextNext.Item, currentNext.Item))
+                    {
+                        currentNext.Item = point;
+                        InvalidateNeighbors(null, currentNext, nextNext);
+                        return;
+                    }
+                }
+                else // Left
+                {
+                    currentNext = CurrentNode.GetNextNode();
+                    if (currentNext != null && !IsPointToTheRightOfOthers(point, currentNext.Item, CurrentNode.Item))
+                    {
+                        CurrentNode.Item = point;
+                        InvalidateNeighbors(currentPrevious, CurrentNode, currentNext);
+                        return;
+                    }
+
+                    var previousPrevious = currentPrevious.GetPreviousNode();
+                    if (previousPrevious != null && !IsPointToTheRightOfOthers(previousPrevious.Item, point, currentPrevious.Item))
+                    {
+                        currentPrevious.Item = point;
+                        InvalidateNeighbors(previousPrevious, currentPrevious, null);
+                        return;
+                    }
+                }
+
+                // Should insert but no invalidation is required. (That's why we need to insert... can't replace an adjacent neightbor)
+                AvlNode<MutablePoint> newNode = new AvlNode<MutablePoint>();
+                if (insertionSide == Side.Right)
+                {
+                    newNode.Parent = CurrentNode;
+                    newNode.Item = point;
+                    CurrentNode.Right = newNode;
+                    this.AddBalance(newNode.Parent, -1);
+                }
+                else // Left
+                {
+                    newNode.Parent = CurrentNode;
+                    newNode.Item = point;
+                    CurrentNode.Left = newNode;
+                    this.AddBalance(newNode.Parent, 1);
+                }
+
+                return;
+            }
+
+            return;
+        }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool CanQuickReject(ref MutablePoint pt, ref MutablePoint ptHull)
+        {
+            return pt.X >= ptHull.X && pt.Y >= ptHull.Y;
+        }
+    }
+}

--- a/src/Spatial/Internals/ConvexHull/QuadrantSpecific4.cs
+++ b/src/Spatial/Internals/ConvexHull/QuadrantSpecific4.cs
@@ -1,0 +1,227 @@
+﻿namespace MathNet.Spatial.Internals
+{
+    using System;
+    using System.Linq;
+
+    internal class QuadrantSpecific4 : Quadrant
+    {
+        internal QuadrantSpecific4(MutablePoint[] listOfPoint, Func<MutablePoint, MutablePoint, int> comparer)
+            : base(listOfPoint, new QComparer(comparer))
+        {
+        }
+
+        protected override void SetQuadrantLimits()
+        {
+            MutablePoint firstPoint = this.ListOfPoint.First();
+
+            double rightX = firstPoint.X;
+            double rightY = firstPoint.Y;
+
+            double bottomX = rightX;
+            double bottomY = rightY;
+
+            foreach (var point in ListOfPoint)
+            {
+                if (point.X >= rightX)
+                {
+                    if (point.X == rightX)
+                    {
+                        if (point.Y < rightY)
+                        {
+                            rightY = point.Y;
+                        }
+                    }
+                    else
+                    {
+                        rightX = point.X;
+                        rightY = point.Y;
+                    }
+                }
+
+                if (point.Y <= bottomY)
+                {
+                    if (point.Y == bottomY)
+                    {
+                        if (point.X > bottomX)
+                        {
+                            bottomX = point.X;
+                        }
+                    }
+                    else
+                    {
+                        bottomX = point.X;
+                        bottomY = point.Y;
+                    }
+                }
+            }
+
+            FirstPoint = new MutablePoint(bottomX, bottomY);
+            LastPoint = new MutablePoint(rightX, rightY);
+            RootPoint = new MutablePoint(bottomX, rightY);
+        }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected override bool IsGoodQuadrantForPoint(MutablePoint pt)
+        {
+            if (pt.X > this.RootPoint.X && pt.Y < this.RootPoint.Y)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Iterate over each points to see if we can add it has a ConvexHull point.
+        /// It is specific by Quadrant to improve efficiency.
+        /// </summary>
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal override void ProcessPoint(ref MutablePoint point)
+        {
+            CurrentNode = Root;
+            AvlNode<MutablePoint> currentPrevious = null;
+            AvlNode<MutablePoint> currentNext = null;
+
+            while (CurrentNode != null)
+            {
+                //if (CanQuickReject(point, CurrentNode.Item))
+                //{
+                //	return false;
+                //}
+
+                var insertionSide = Side.Unknown;
+                if (point.X > CurrentNode.Item.X)
+                {
+                    if (CurrentNode.Right != null)
+                    {
+                        CurrentNode = CurrentNode.Right;
+                        continue;
+                    }
+
+                    currentNext = CurrentNode.GetNextNode();
+                    if (CanQuickReject(ref point, ref currentNext.Item))
+                    {
+                        return;
+                    }
+
+                    if (!IsPointToTheRightOfOthers(CurrentNode.Item, currentNext.Item, point))
+                    {
+                        return;
+                    }
+
+                    if (CurrentNode.Item == point) // Ensure to have no duplicate
+                    {
+                        continue;
+                    }
+
+                    insertionSide = Side.Right;
+                }
+                else if (point.X < CurrentNode.Item.X)
+                {
+                    if (CurrentNode.Left != null)
+                    {
+                        CurrentNode = CurrentNode.Left;
+                        continue;
+                    }
+
+                    currentPrevious = CurrentNode.GetPreviousNode();
+                    if (CanQuickReject(ref point, ref currentPrevious.Item))
+                    {
+                        return;
+                    }
+
+                    if (!IsPointToTheRightOfOthers(currentPrevious.Item, CurrentNode.Item, point))
+                    {
+                        return;
+                    }
+
+                    if (CurrentNode.Item == point) // Ensure to have no duplicate
+                    {
+                        continue;
+                    }
+
+                    insertionSide = Side.Left;
+                }
+                else
+                {
+                    if (point.Y >= CurrentNode.Item.Y)
+                    {
+                        return; // invalid point
+                    }
+
+                    // Replace CurrentNode point with point
+                    CurrentNode.Item = point;
+                    InvalidateNeighbors(CurrentNode.GetPreviousNode(), CurrentNode, CurrentNode.GetNextNode());
+                    return;
+                }
+
+                //We should insert the point
+
+                // Try to optimize and verify if can replace a node instead insertion to minimize tree balancing
+                if (insertionSide == Side.Right)
+                {
+                    currentPrevious = CurrentNode.GetPreviousNode();
+                    if (currentPrevious != null && !IsPointToTheRightOfOthers(currentPrevious.Item, point, CurrentNode.Item))
+                    {
+                        CurrentNode.Item = point;
+                        InvalidateNeighbors(currentPrevious, CurrentNode, currentNext);
+                        return;
+                    }
+
+                    var nextNext = currentNext.GetNextNode();
+                    if (nextNext != null && !IsPointToTheRightOfOthers(point, nextNext.Item, currentNext.Item))
+                    {
+                        currentNext.Item = point;
+                        InvalidateNeighbors(null, currentNext, nextNext);
+                        return;
+                    }
+                }
+                else // Left
+                {
+                    currentNext = CurrentNode.GetNextNode();
+                    if (currentNext != null && !IsPointToTheRightOfOthers(point, currentNext.Item, CurrentNode.Item))
+                    {
+                        CurrentNode.Item = point;
+                        InvalidateNeighbors(currentPrevious, CurrentNode, currentNext);
+                        return;
+                    }
+
+                    var previousPrevious = currentPrevious.GetPreviousNode();
+                    if (previousPrevious != null && !IsPointToTheRightOfOthers(previousPrevious.Item, point, currentPrevious.Item))
+                    {
+                        currentPrevious.Item = point;
+                        InvalidateNeighbors(previousPrevious, currentPrevious, null);
+                        return;
+                    }
+                }
+
+                // Should insert but no invalidation is required. (That's why we need to insert... can't replace an adjacent neightbor)
+                AvlNode<MutablePoint> newNode = new AvlNode<MutablePoint>();
+                if (insertionSide == Side.Right)
+                {
+                    newNode.Parent = CurrentNode;
+                    newNode.Item = point;
+                    CurrentNode.Right = newNode;
+                    this.AddBalance(newNode.Parent, -1);
+                }
+                else // Left
+                {
+                    newNode.Parent = CurrentNode;
+                    newNode.Item = point;
+                    CurrentNode.Left = newNode;
+                    this.AddBalance(newNode.Parent, 1);
+                }
+
+                return;
+            }
+
+            return;
+        }
+
+        //[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool CanQuickReject(ref MutablePoint pt, ref MutablePoint ptHull)
+        {
+            return pt.X <= ptHull.X && pt.Y >= ptHull.Y;
+        }
+    }
+}

--- a/src/Spatial/Spatial.csproj
+++ b/src/Spatial/Spatial.csproj
@@ -50,6 +50,17 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Euclidean\Circle2D.cs" />
+    <Compile Include="Internals\ConvexHull\QComparer.cs" />
+    <Compile Include="Internals\AvlTreeSet\AvlNode.cs" />
+    <Compile Include="Internals\AvlTreeSet\AvlNodeItemEnumerator.cs" />
+    <Compile Include="Internals\AvlTreeSet\AvlTreeSet.cs" />
+    <Compile Include="Internals\ConvexHull\ConvexHull.cs" />
+    <Compile Include="Internals\ConvexHull\MutablePoint.cs" />
+    <Compile Include="Internals\ConvexHull\Quadrant.cs" />
+    <Compile Include="Internals\ConvexHull\QuadrantSpecific1.cs" />
+    <Compile Include="Internals\ConvexHull\QuadrantSpecific2.cs" />
+    <Compile Include="Internals\ConvexHull\QuadrantSpecific3.cs" />
+    <Compile Include="Internals\ConvexHull\QuadrantSpecific4.cs" />
     <Compile Include="Euclidean\EulerAngles.cs" />
     <Compile Include="Euclidean\Line2D.cs" />
     <Compile Include="Euclidean\Matrix2D.cs" />

--- a/src/SpatialUnitTests/Euclidean/Polygon2DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Polygon2DTests.cs
@@ -38,7 +38,7 @@
         {
             var polygon = this.TestPolygon1();
             var checkList = new List<Point2D> { new Point2D(0, 0), new Point2D(0.25, 0.5), new Point2D(1, 1), new Point2D(-1, 1), new Point2D(0.5, -0.5) };
-            CollectionAssert.AreEqual(checkList, polygon);
+            CollectionAssert.AreEqual(checkList, polygon.Vertices);
         }
 
         [TestCase("0,0;2,2;3,1;2,0", "1,1", "1,1;3,3;4,2;3,1")]
@@ -124,7 +124,7 @@
         [TestCase("0.87,0.39;0.83,0.42;0.75,0.62;0.91,0.49;0.18,0.63;0.17,0.95;0.22,0.5;0.93,0.41;0.66,0.79;0.32,0.42", "0.66,0.79;0.17,0.95;0.18,0.63;0.22,0.5;0.32,0.42;0.87,0.39;0.93,0.41;0.91,0.49")]
         [TestCase("0.18,0.39;0.91,0.3;0.35,0.53;0.91,0.38;0.49,0.28;0.61,0.22;0.27,0.18;0.44,0.06;0.5,0.79;0.78,0.22", "0.91,0.38;0.5,0.79;0.18,0.39;0.27,0.18;0.44,0.06;0.78,0.22;0.91,0.3")]
         [TestCase("0.89,0.55;0.98,0.24;0.03,0.2;0.51,0.99;0.72,0.32;0.56,0.87;0.1,0.75;0.64,0.16;0.82,0.73;0.17,0.46", "0.89,0.55;0.82,0.73;0.51,0.99;0.1,0.75;0.03,0.2;0.64,0.16;0.98,0.24")]
-       // [TestCase("-201.573,100.940;197.083,21.031;161.021,-29.414;114.223,-23.998;230.290,-68.246;-32.272,182.239;-173.345,72.736;-175.435,-176.273;90.810,-97.350;-196.942,216.594;67.759,-162.464;67.454,-174.844;-89.116,171.982;-18.421,11.935;73.816,-180.169;-103.560,-36.297;-233.800,194.296;-64.463,166.811;-17.182,83.403;-72.010,219.944")]
+        [TestCase("-201.573,100.940;197.083,21.031;161.021,-29.414;114.223,-23.998;230.290,-68.246;-32.272,182.239;-173.345,72.736;-175.435,-176.273;90.810,-97.350;-196.942,216.594;67.759,-162.464;67.454,-174.844;-89.116,171.982;-18.421,11.935;73.816,-180.169;-103.560,-36.297;-233.800,194.296;-64.463,166.811;-17.182,83.403;-72.010,219.944", "-72.01,219.944;-196.942,216.594;-233.8,194.296;-175.435,-176.273;73.816,-180.169;230.29,-68.246;197.083,21.031")]
         public void ConvexHullTest(string points, string expected)
         {
             var testPoints = (from x in points.Split(';') select Point2D.Parse(x)).ToList();
@@ -133,17 +133,24 @@
             var hullClockwise = Polygon2D.GetConvexHullFromPoints(testPoints, true);
 
             var ClockwiseVerticies = hullClockwise.Vertices;
+            CollectionAssert.AreEqual(expectedPoints, ClockwiseVerticies);
+            /*
             for (var i = 0; i < hullClockwise.VertexCount; i++)
             {
                 Assert.That(ClockwiseVerticies[i], Is.EqualTo(expectedPoints[i]));
             }
+            */
 
             var hullCounterClockwise = Polygon2D.GetConvexHullFromPoints(testPoints, false);
-            var CounterClockwiseVerticies = hullCounterClockwise.Vertices;
+            var counterClockwiseVerticies = hullCounterClockwise.Vertices;
+            expectedPoints.Reverse();
+            CollectionAssert.AreEqual(expectedPoints, counterClockwiseVerticies);
+            /*
             for (var i = 0; i < hullCounterClockwise.VertexCount; i++)
             {
-                Assert.That(CounterClockwiseVerticies[i], Is.EqualTo(expectedPoints[hullCounterClockwise.VertexCount - 1 - i]));
+                Assert.That(counterClockwiseVerticies[i], Is.EqualTo(expectedPoints[hullCounterClockwise.VertexCount - 1 - i]));
             }
+            */
 
             var pointsNotOnConvexHull = testPoints.Except(hullCounterClockwise);
             foreach (var pointNotOnConvexHull in pointsNotOnConvexHull)
@@ -156,7 +163,7 @@
             // then that point should be outside the new convex hull; if it's inside then our new
             // convex hull is the actual convex hull, which means the original one wasn't!
 
-            foreach (var pointToRemove in CounterClockwiseVerticies)
+            foreach (var pointToRemove in counterClockwiseVerticies)
             {
                 var convexHullWithPointRemoved = new Polygon2D(hullCounterClockwise.Except(new[] { pointToRemove }));
                 var pointIsInsideConvexHull =


### PR DESCRIPTION
Implements a single threated version of Ouellet's algorithm O(n log h) for convex hull calculation this is based upon the work of Lui and Chen (2007) and replaces the Quickhull method previously used.
Liu, G. & Chen, C. J. Zhejiang Univ. - Sci. A (2007) 8: 1210. https://doi.org/10.1631/jzus.2007.A1210 

This provides a fix #59 

Also changed assessors for Vertices and Edges to be enumerators.