### PR TITLE
New LineSegment2D

### DIFF
--- a/src/Spatial/Euclidean/LIneSegment2D.cs
+++ b/src/Spatial/Euclidean/LIneSegment2D.cs
@@ -30,7 +30,7 @@
         {
             if (startPoint == endPoint)
             {
-                throw new ArgumentException("The Line2D starting and ending points cannot be identical");
+                throw new ArgumentException("The segment starting and ending points cannot be identical");
             }
 
             this.StartPoint = startPoint;
@@ -88,7 +88,7 @@
         /// </summary>
         /// <param name="vector">A vector to apply</param>
         /// <returns>A new translated linesegment</returns>
-        public LineSegment2D Translate(Vector2D vector)
+        public LineSegment2D TranslateBy(Vector2D vector)
         {
             var startVector = this.StartPoint.ToVector2D().Add(vector);
             var endVector = this.EndPoint.ToVector2D().Add(vector);

--- a/src/Spatial/Euclidean/LIneSegment2D.cs
+++ b/src/Spatial/Euclidean/LIneSegment2D.cs
@@ -1,0 +1,224 @@
+﻿namespace MathNet.Spatial.Euclidean
+{
+    using System;
+    using System.Diagnostics.Contracts;
+    using MathNet.Spatial.Units;
+
+    /// <summary>
+    /// This structure represents a line between two points in 2-space.  It allows for operations such as
+    /// computing the length, direction, comparisons, and shifting by a vector.
+    /// </summary>
+    public struct LineSegment2D : IEquatable<LineSegment2D>
+    {
+        /// <summary>
+        /// The starting point of the line segment
+        /// </summary>
+        public readonly Point2D StartPoint;
+
+        /// <summary>
+        /// The end point of the line segment
+        /// </summary>
+        public readonly Point2D EndPoint;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LineSegment2D"/> struct.
+        /// Throws an ArgumentException if the <paramref name="startPoint"/> is equal to the <paramref name="endPoint"/>.
+        /// </summary>
+        /// <param name="startPoint">the starting point of the line segment.</param>
+        /// <param name="endPoint">the ending point of the line segment</param>
+        public LineSegment2D(Point2D startPoint, Point2D endPoint)
+        {
+            if (startPoint == endPoint)
+            {
+                throw new ArgumentException("The Line2D starting and ending points cannot be identical");
+            }
+
+            this.StartPoint = startPoint;
+            this.EndPoint = endPoint;
+        }
+
+        /// <summary>
+        /// Gets the distance from <see cref="StartPoint"/> to <see cref="EndPoint"/>
+        /// </summary>
+        [Pure]
+        public double Length => this.StartPoint.DistanceTo(this.EndPoint);
+
+        /// <summary>
+        /// Gets a normalized vector in the direction from <see cref="StartPoint"/> to <see cref="EndPoint"/>
+        /// </summary>
+        [Pure]
+        public Vector2D Direction => this.StartPoint.VectorTo(this.EndPoint).Normalize();
+
+        /// <summary>
+        /// Returns a value that indicates whether each pair of elements in two specified lines is equal.
+        /// </summary>
+        /// <param name="left">The first line to compare</param>
+        /// <param name="right">The second line to compare</param>
+        /// <returns>True if the lines are the same; otherwise false.</returns>
+        public static bool operator ==(LineSegment2D left, LineSegment2D right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether any pair of elements in two specified lines is not equal.
+        /// </summary>
+        /// <param name="left">The first line to compare</param>
+        /// <param name="right">The second line to compare</param>
+        /// <returns>True if the lines are different; otherwise false.</returns>
+        public static bool operator !=(LineSegment2D left, LineSegment2D right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns a new <see cref="Line2D"/> from a pair of strings which represent points.
+        /// See <see cref="Point2D.Parse(string, IFormatProvider)" /> for details on acceptable formats.
+        /// </summary>
+        /// <param name="startPointString">The string representation of the first point.</param>
+        /// <param name="endPointString">The string representation of the second point.</param>
+        /// <returns>A line segment from the first point to the second point.</returns>
+        public static LineSegment2D Parse(string startPointString, string endPointString)
+        {
+            return new LineSegment2D(Point2D.Parse(startPointString), Point2D.Parse(endPointString));
+        }
+
+        /// <summary>
+        /// Translates a line according to a provided vector
+        /// </summary>
+        /// <param name="vector">A vector to apply</param>
+        /// <returns>A new translated linesegment</returns>
+        public LineSegment2D Translate(Vector2D vector)
+        {
+            var startVector = this.StartPoint.ToVector2D().Add(vector);
+            var endVector = this.EndPoint.ToVector2D().Add(vector);
+            return new LineSegment2D(new Point2D(startVector.X, startVector.Y), new Point2D(endVector.X, endVector.Y));
+        }
+
+        /// <summary>
+        /// Returns a new linesegment between the clostes point on this line segment and a point.
+        /// </summary>
+        /// <param name="p">the point to create a line to</param>
+        /// <returns>A linesegment between the point and the nearest point on this segment.</returns>
+        [Pure]
+        public LineSegment2D LineTo(Point2D p)
+        {
+            return new LineSegment2D(this.ClosestPointTo(p), p);
+        }
+
+        /// <summary>
+        /// Returns the closest point on the line to the given point.
+        /// </summary>
+        /// <param name="p">The point that the returned point is the closest point on the line to</param>
+        /// <returns>The closest point on the line to the provided point</returns>
+        [Pure]
+        public Point2D ClosestPointTo(Point2D p)
+        {
+            var v = this.StartPoint.VectorTo(p);
+            var dotProduct = v.DotProduct(this.Direction);
+
+            if (dotProduct < 0)
+            {
+                dotProduct = 0;
+            }
+
+            var l = this.Length;
+            if (dotProduct > l)
+            {
+                dotProduct = l;
+            }
+
+            var alongVector = dotProduct * this.Direction;
+            return this.StartPoint + alongVector;
+        }
+
+        /// <summary>
+        /// Compute the intersection between two lines if the angle between them is greater than a specified
+        /// angle tolerance.
+        /// </summary>
+        /// <param name="other">The other line to compute the intersection with</param>
+        /// <param name="intersection">When this method returns, contains the intersection point, if the conversion succeeded, or the default point if the conversion failed.</param>
+        /// <param name="tolerance">The tolerance used when checking if the lines are parallel</param>
+        /// <returns>True if an intersection exists; otherwise false</returns>
+        [Pure]
+        public bool TryIntersect(LineSegment2D other, out Point2D intersection, Angle tolerance)
+        {
+            if (this.IsParallelTo(other, tolerance))
+            {
+                intersection = default(Point2D);
+                return false;
+            }
+
+            // http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
+            var p = this.StartPoint;
+            var q = other.StartPoint;
+            var r = this.StartPoint.VectorTo(this.EndPoint);
+            var s = other.StartPoint.VectorTo(other.EndPoint);
+
+            var t = (q - p).CrossProduct(s) / r.CrossProduct(s);
+
+            intersection = p + (t * r);
+            return true;
+        }
+
+        /// <summary>
+        /// Checks to determine whether or not two line segments are parallel to each other within a specified angle tolerance
+        /// </summary>
+        /// <param name="other">The other line to check this one against</param>
+        /// <param name="tolerance">If the angle between line directions is less than this value, the method returns true</param>
+        /// <returns>True if the lines are parallel within the angle tolerance, false if they are not</returns>
+        [Pure]
+        public bool IsParallelTo(LineSegment2D other, Angle tolerance)
+        {
+            return this.Direction.IsParallelTo(other.Direction, tolerance);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public override string ToString()
+        {
+            return $"StartPoint: {this.StartPoint}, EndPoint: {this.EndPoint}";
+        }
+
+        /// <summary>
+        /// Returns a value to indicate if a pair of line segments are equal
+        /// </summary>
+        /// <param name="other">The line segment to compare against.</param>
+        /// <param name="tolerance">A tolerance (epsilon) to adjust for floating point error</param>
+        /// <returns>True if the line segments are equal; otherwise false</returns>
+        [Pure]
+        public bool Equals(LineSegment2D other, double tolerance)
+        {
+            return this.StartPoint.Equals(other.StartPoint, tolerance) && this.EndPoint.Equals(other.EndPoint, tolerance);
+        }
+
+        /// <inheritdoc/>
+        [Pure]
+        public bool Equals(LineSegment2D other)
+        {
+            return this.StartPoint.Equals(other.StartPoint) && this.EndPoint.Equals(other.EndPoint);
+        }
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            return obj is LineSegment2D d && this.Equals(d);
+        }
+
+        /// <inheritdoc />
+        [Pure]
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (this.StartPoint.GetHashCode() * 397) ^ this.EndPoint.GetHashCode();
+            }
+        }
+    }
+}

--- a/src/Spatial/Spatial.csproj
+++ b/src/Spatial/Spatial.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Euclidean\Circle2D.cs" />
+    <Compile Include="Euclidean\LIneSegment2D.cs" />
     <Compile Include="Internals\ConvexHull\QComparer.cs" />
     <Compile Include="Internals\AvlTreeSet\AvlNode.cs" />
     <Compile Include="Internals\AvlTreeSet\AvlNodeItemEnumerator.cs" />

--- a/src/SpatialUnitTests/Euclidean/LineSegment2DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/LineSegment2DTests.cs
@@ -1,0 +1,156 @@
+﻿namespace MathNet.Spatial.UnitTests.Euclidean
+{
+    using System;
+    using MathNet.Spatial.Euclidean;
+    using MathNet.Spatial.Units;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class LineSegment2DTests
+    {
+        [Test]
+        public void Constructor()
+        {
+            var p1 = new Point2D(0, 0);
+            var p2 = new Point2D(1, 1);
+            var line = new LineSegment2D(p1, p2);
+
+            AssertGeometry.AreEqual(p1, line.StartPoint);
+            AssertGeometry.AreEqual(p2, line.EndPoint);
+        }
+
+        [Test]
+        public void ConstructorThrowsErrorOnSamePoint()
+        {
+            var p1 = new Point2D(1, -1);
+            var p2 = new Point2D(1, -1);
+            Assert.Throws<ArgumentException>(() => new LineSegment2D(p1, p2));
+        }
+
+        [TestCase("0,0", "1,0", 1)]
+        [TestCase("0,0", "0,1", 1)]
+        [TestCase("0,0", "-1,0", 1)]
+        [TestCase("0,-1", "0,1", 2)]
+        [TestCase("-1,-1", "2,2", 4.24264068711)]
+        public void LineLength(string p1s, string p2s, double expected)
+        {
+            var p1 = Point2D.Parse(p1s);
+            var p2 = Point2D.Parse(p2s);
+            var line = new LineSegment2D(p1, p2);
+            var len = line.Length;
+
+            Assert.AreEqual(expected, len, 1e-7);
+        }
+
+        [TestCase("0,0", "4,0", "1,0")]
+        [TestCase("3,0", "0,0", "-1,0")]
+        [TestCase("2.7,-2.7", "0,0", "-0.707106781,0.707106781")]
+        [TestCase("11,-1", "11,1", "0,1")]
+        public void LineDirection(string p1s, string p2s, string exs)
+        {
+            var p1 = Point2D.Parse(p1s);
+            var p2 = Point2D.Parse(p2s);
+            var ex = Vector2D.Parse(exs);
+            var line = new LineSegment2D(p1, p2);
+
+            AssertGeometry.AreEqual(ex, line.Direction);
+        }
+
+        [TestCase("0,0", "10,10", "0,0", "10,10", true)]
+        [TestCase("0,0", "10,10", "0,0", "10,11", false)]
+        public void EqualityOperator(string p1s, string p2s, string p3s, string p4s, bool expected)
+        {
+            var l1 = LineSegment2D.Parse(p1s, p2s);
+            var l2 = LineSegment2D.Parse(p3s, p4s);
+
+            Assert.AreEqual(expected, l1 == l2);
+        }
+
+        [TestCase("0,0", "10,10", "0,0", "10,10", false)]
+        [TestCase("0,0", "10,10", "0,0", "10,11", true)]
+        public void InequalityOperator(string p1s, string p2s, string p3s, string p4s, bool expected)
+        {
+            var l1 = new LineSegment2D(Point2D.Parse(p1s), Point2D.Parse(p2s));
+            var l2 = new LineSegment2D(Point2D.Parse(p3s), Point2D.Parse(p4s));
+
+            Assert.AreEqual(expected, l1 != l2);
+        }
+
+        [Test]
+        public void EqualityComparisonFalseAgainstNull()
+        {
+            var line = new LineSegment2D(default(Point2D), new Point2D(1, 1));
+            Assert.IsFalse(line.Equals(null));
+        }
+
+        [TestCase("0,0", "1,-1", Description = "Check start point")]
+        [TestCase("1,0", "1,-1")]
+        [TestCase("1,-2", "1,-1")]
+        [TestCase("4,0", "3,-1", Description = "Check end point")]
+        [TestCase("3,0", "3,-1")]
+        [TestCase("3,-3", "3,-1")]
+        [TestCase("1.5,0", "1.5,-1", Description = "Check near middle")]
+        [TestCase("1.5,-2", "1.5,-1")]
+        public void LineToBetweenEndPoints(string ptest, string exs)
+        {
+            var line = LineSegment2D.Parse("1,-1", "3,-1");
+            var point = Point2D.Parse(ptest);
+            var expPoint = Point2D.Parse(exs);
+            var expLine = new LineSegment2D(expPoint, point);
+
+            Assert.AreEqual(expLine, line.LineTo(point));
+        }
+
+        [TestCase("0,0", "1,0", "0,0", "0,0")]
+        [TestCase("0,0", "1,0", "1,0", "1,0")]
+        [TestCase("0,0", "1,0", ".25,1", ".25,0")]
+        [TestCase("0,0", "1,0", "-1,0", "0,0")]
+        [TestCase("0,0", "1,0", "3,0", "1,0")]
+        public void ClosestPointToWithinSegment(string start, string end, string point, string expected)
+        {
+            var line = LineSegment2D.Parse(start, end);
+            var p = Point2D.Parse(point);
+            var e = Point2D.Parse(expected);
+
+            Assert.AreEqual(e, line.ClosestPointTo(p));
+        }
+
+        [TestCase("0,0", "2,2", "1,0", "1,2", "1,1")]
+        [TestCase("0,0", "2,2", "0,1", "2,1", "1,1")]
+        [TestCase("0,0", "2,2", "-1,-5", "-1,0", "-1,-1")]
+        public void IntersectWithTest(string s1, string e1, string s2, string e2, string expected)
+        {
+            var line1 = LineSegment2D.Parse(s1, e1);
+            var line2 = LineSegment2D.Parse(s2, e2);
+            var e = string.IsNullOrEmpty(expected) ? (Point2D?)null : Point2D.Parse(expected);
+            bool success = line1.TryIntersect(line2, out var result, Angle.FromRadians(0.001));
+            Assert.IsTrue(success);
+            Assert.AreEqual(e, result);
+        }
+
+        [TestCase("0,0", "0,1", "1,1", "1,2", 0.0001, true)]
+        [TestCase("0,0", "0,-1", "1,1", "1,2", 0.0001, true)]
+        [TestCase("0,0", "0.5,-1", "1,1", "1,2", 0.0001, false)]
+        [TestCase("0,0", "0.00001,-1.0000", "1,1", "1,2", 0.0001, false)]
+        [TestCase("0,0", "0,1", "1,1", "1,2", 0.01, true)]
+        [TestCase("0,0", "0,-1", "1,1", "1,2", 0.01, true)]
+        [TestCase("0,0", "0.5,-1", "1,1", "1,2", 0.01, false)]
+        [TestCase("0,0", "0.001,-1.0000", "1,1", "1,2", 0.05, false)]
+        [TestCase("0,0", "0.001,-1.0000", "1,1", "1,2", 0.06, true)]
+        public void IsParallelToWithinAngleTol(string s1, string e1, string s2, string e2, double degreesTol, bool expected)
+        {
+            var line1 = LineSegment2D.Parse(s1, e1);
+            var line2 = LineSegment2D.Parse(s2, e2);
+
+            Assert.AreEqual(expected, line1.IsParallelTo(line2, Angle.FromDegrees(degreesTol)));
+        }
+
+        [Test]
+        public void ToStringCheck()
+        {
+            var check = LineSegment2D.Parse("0,0", "1,1").ToString();
+
+            Assert.AreEqual("StartPoint: (0,\u00A00), EndPoint: (1,\u00A01)", check);
+        }
+    }
+}

--- a/src/SpatialUnitTests/Euclidean/LineSegment2DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/LineSegment2DTests.cs
@@ -101,6 +101,17 @@
             Assert.AreEqual(expLine, line.LineTo(point));
         }
 
+        [TestCase("1,1", "3,1", "1,1", "2,2", "4,2")]
+        [TestCase("1,1", "3,1", "-1,-1", "0,0", "2,0")]
+        public void TranslateBy(string spoint1, string spoint2, string svector, string spoint3, string spoint4)
+        {
+            var line = LineSegment2D.Parse(spoint1, spoint2);
+            var expected = LineSegment2D.Parse(spoint3, spoint4);
+            var vector = Vector2D.Parse(svector);
+            Assert.AreEqual(expected.Length, line.Length);
+            Assert.AreEqual(expected, line.TranslateBy(vector));
+        }
+
         [TestCase("0,0", "1,0", "0,0", "0,0")]
         [TestCase("0,0", "1,0", "1,0", "1,0")]
         [TestCase("0,0", "1,0", ".25,1", ".25,0")]

--- a/src/SpatialUnitTests/SpatialUnitTests.csproj
+++ b/src/SpatialUnitTests/SpatialUnitTests.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="Euclidean\Circle2DTests.cs" />
     <Compile Include="Euclidean\Circle3DTests.cs" />
+    <Compile Include="Euclidean\LineSegment2DTests.cs" />
     <Compile Include="Euclidean\Line2DTests.cs" />
     <Compile Include="Euclidean\Point2DTests.cs" />
     <Compile Include="Euclidean\Polygon2DTests.cs" />


### PR DESCRIPTION
Partial fix for issue #99.

Most methods are copied over from Line2D.  Changes are:
Only kept comparison operator overloads - other operators not carried over
new equals overload with tolerance
new method Translate
IsParallel tolerance only method kept
Intersection changed to TryIntersect with tolerance

Should any other methods be included?



