### PR TITLE
Final changeset for #99

### DIFF
--- a/src/Spatial/Euclidean/CoordinateSystem.cs
+++ b/src/Spatial/Euclidean/CoordinateSystem.cs
@@ -501,9 +501,20 @@ namespace MathNet.Spatial.Euclidean
         /// </summary>
         /// <param name="l"></param>
         /// <returns></returns>
+        [Obsolete("Use LineSegment3D, Obsolete from 2017-12-10")]
         public Line3D Transform(Line3D l)
         {
             return new Line3D(this.Transform(l.StartPoint), this.Transform(l.EndPoint));
+        }
+
+        /// <summary>
+        /// Transforms a line segement.
+        /// </summary>
+        /// <param name="l">A line segment</param>
+        /// <returns>The transformed line sgement</returns>
+        public LineSegment3D Transform(LineSegment3D l)
+        {
+            return new LineSegment3D(this.Transform(l.StartPoint), this.Transform(l.EndPoint));
         }
 
         /// <summary>

--- a/src/Spatial/Euclidean/Plane.cs
+++ b/src/Spatial/Euclidean/Plane.cs
@@ -220,11 +220,19 @@
             return p - projectionVector;
         }
 
+        [Obsolete("Use LineSegment3D instead, obsolete from 2017-12-10")]
         public Line3D Project(Line3D line3DToProject)
         {
             var projectedStartPoint = this.Project(line3DToProject.StartPoint);
             var projectedEndPoint = this.Project(line3DToProject.EndPoint);
             return new Line3D(projectedStartPoint, projectedEndPoint);
+        }
+
+        public LineSegment3D Project(LineSegment3D line3DToProject)
+        {
+            var projectedStartPoint = this.Project(line3DToProject.StartPoint);
+            var projectedEndPoint = this.Project(line3DToProject.EndPoint);
+            return new LineSegment3D(projectedStartPoint, projectedEndPoint);
         }
 
         public Ray3D Project(Ray3D rayToProject)
@@ -293,7 +301,42 @@
         /// <param name="line">A line segment</param>
         /// <param name="tolerance">A tolerance (epsilon) to account for floating point error.</param>
         /// <returns>Intersection Point or null</returns>
+        [Obsolete("Use LineSegment3D instead, Obsolete from 2017-12-10")]
         public Point3D? IntersectionWith(Line3D line, double tolerance = float.Epsilon)
+        {
+            if (line.Direction.IsPerpendicularTo(this.Normal, tolerance))
+            {
+                // either parallel or lies in the plane
+                var projectedPoint = this.Project(line.StartPoint, line.Direction);
+                if (projectedPoint == line.StartPoint)
+                {
+                    throw new InvalidOperationException("Line lies in the plane");
+                }
+
+                // Line and plane are parallel
+                return null;
+            }
+
+            var d = this.SignedDistanceTo(line.StartPoint);
+            var u = line.StartPoint.VectorTo(line.EndPoint);
+            var t = -1 * d / u.DotProduct(this.Normal);
+            if (t > 1 || t < 0)
+            {
+                // They are not intersected
+                return null;
+            }
+
+            return line.StartPoint + (t * u);
+        }
+
+        /// <summary>
+        /// Find intersection between LineSegment3D and Plane
+        /// http://geomalgorithms.com/a05-_intersect-1.html
+        /// </summary>
+        /// <param name="line">A line segment</param>
+        /// <param name="tolerance">A tolerance (epsilon) to account for floating point error.</param>
+        /// <returns>Intersection Point or null</returns>
+        public Point3D? IntersectionWith(LineSegment3D line, double tolerance = float.Epsilon)
         {
             if (line.Direction.IsPerpendicularTo(this.Normal, tolerance))
             {

--- a/src/Spatial/Euclidean/Ray3D.cs
+++ b/src/Spatial/Euclidean/Ray3D.cs
@@ -118,6 +118,19 @@ namespace MathNet.Spatial.Euclidean
         }
 
         /// <summary>
+        /// Returns the shortest line from a point to the ray
+        /// </summary>
+        /// <param name="point3D">A point.</param>
+        /// <returns>A line segment from the point to the closest point on the ray</returns>
+        [Pure]
+        public LineSegment3D ShortestLineTo(Point3D point3D)
+        {
+            var v = this.ThroughPoint.VectorTo(point3D);
+            var alongVector = v.ProjectOn(this.Direction);
+            return new LineSegment3D(this.ThroughPoint + alongVector, point3D);
+        }
+
+        /// <summary>
         /// Returns the point at which this ray intersects with the plane
         /// </summary>
         /// <param name="plane">A geometric plane.</param>

--- a/src/Spatial/Euclidean/Ray3D.cs
+++ b/src/Spatial/Euclidean/Ray3D.cs
@@ -110,6 +110,7 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="point3D">A point.</param>
         /// <returns>A line segment from the point to the closest point on the ray</returns>
         [Pure]
+        [Obsolete("Use ShortestLineTo, Obsolete from 2017-12-11")]
         public Line3D LineTo(Point3D point3D)
         {
             var v = this.ThroughPoint.VectorTo(point3D);

--- a/src/SpatialUnitTests/Euclidean/PlaneTest.cs
+++ b/src/SpatialUnitTests/Euclidean/PlaneTest.cs
@@ -94,9 +94,9 @@
             var rootPoint = new Point3D(0, 0, 1);
             var plane = new Plane(unitVector, rootPoint);
 
-            var line = new Line3D(new Point3D(0, 0, 0), new Point3D(1, 0, 0));
+            var line = new LineSegment3D(new Point3D(0, 0, 0), new Point3D(1, 0, 0));
             var projectOn = plane.Project(line);
-            AssertGeometry.AreEqual(new Line3D(new Point3D(0, 0, 1), new Point3D(1, 0, 1)), projectOn, float.Epsilon);
+            AssertGeometry.AreEqual(new LineSegment3D(new Point3D(0, 0, 1), new Point3D(1, 0, 1)), projectOn, float.Epsilon);
         }
 
         [Test]

--- a/src/SpatialUnitTests/Euclidean/Ray3DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/Ray3DTests.cs
@@ -33,7 +33,7 @@ namespace MathNet.Spatial.UnitTests.Euclidean
         {
             var ray = new Ray3D(new Point3D(0, 0, 0), UnitVector3D.ZAxis);
             var point3D = new Point3D(1, 0, 0);
-            var line3DTo = ray.LineTo(point3D);
+            var line3DTo = ray.ShortestLineTo(point3D);
             AssertGeometry.AreEqual(new Point3D(0, 0, 0), line3DTo.StartPoint);
             AssertGeometry.AreEqual(point3D, line3DTo.EndPoint, float.Epsilon);
         }


### PR DESCRIPTION
Obsolete Line2D/Line3D use in other classes public interfaces
Replace method signatures with identical LineSegment versions
Updated corresponding test cases

Line2D/Line3D should be made obsolete in the following release

Provides final fix #99 