### PR TITLE
Equality Fixes - Point2D, Circle2D, Polygon2D, Vector2D, LineSegment2D

### DIFF
--- a/src/Spatial/Euclidean/Circle2D.cs
+++ b/src/Spatial/Euclidean/Circle2D.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics.Contracts;
+    using MathNet.Spatial.Internals;
 
     /// <summary>
     /// Describes a standard 2 dimensional circle
@@ -104,34 +105,33 @@
             return new Circle2D(center, center.DistanceTo(pointA));
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns a value to indicate if a pair of circles are equal
+        /// </summary>
+        /// <param name="c">The circle to compare against.</param>
+        /// <param name="tolerance">A tolerance (epsilon) to adjust for floating point error</param>
+        /// <returns>true if the points are equal; otherwise false</returns>
         [Pure]
-        public bool Equals(Circle2D other)
+        public bool Equals(Circle2D c, double tolerance)
         {
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            return this.Radius == other.Radius && this.Center == other.Center;
-        }
-
-        /// <inheritdoc />
-        [Pure]
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
+            if (tolerance < 0)
             {
-                return false;
+                throw new ArgumentException("epsilon < 0");
             }
 
-            return obj is Circle2D d && this.Equals(d);
+            return Math.Abs(c.Radius - this.Radius) < tolerance && this.Center.Equals(c.Center, tolerance);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (this.Center.GetHashCode() * 397) ^ this.Radius.GetHashCode();
-            }
-        }
+        public bool Equals(Circle2D c) => this.Radius.Equals(c.Radius) && this.Center.Equals(c.Center);
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool Equals(object obj) => obj is Circle2D c && this.Equals(c);
+
+        /// <inheritdoc />
+        [Pure]
+        public override int GetHashCode() => HashCode.Combine(this.Center, this.Radius);
     }
 }

--- a/src/Spatial/Euclidean/LineSegment2D.cs
+++ b/src/Spatial/Euclidean/LineSegment2D.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics.Contracts;
+    using MathNet.Spatial.Internals;
     using MathNet.Spatial.Units;
 
     /// <summary>
@@ -194,31 +195,14 @@
 
         /// <inheritdoc/>
         [Pure]
-        public bool Equals(LineSegment2D other)
-        {
-            return this.StartPoint.Equals(other.StartPoint) && this.EndPoint.Equals(other.EndPoint);
-        }
+        public bool Equals(LineSegment2D l) => this.StartPoint.Equals(l.StartPoint) && this.EndPoint.Equals(l.EndPoint);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj)
-        {
-            if (obj is null)
-            {
-                return false;
-            }
-
-            return obj is LineSegment2D d && this.Equals(d);
-        }
+        public override bool Equals(object obj) => obj is LineSegment2D l && this.Equals(l);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (this.StartPoint.GetHashCode() * 397) ^ this.EndPoint.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(this.StartPoint, this.EndPoint);
     }
 }

--- a/src/Spatial/Euclidean/Point2D.cs
+++ b/src/Spatial/Euclidean/Point2D.cs
@@ -394,15 +394,6 @@ namespace MathNet.Spatial.Euclidean
             return $"({this.X.ToString(format, numberFormatInfo)}{separator}\u00A0{this.Y.ToString(format, numberFormatInfo)})";
         }
 
-        /// <inheritdoc />
-        [Pure]
-        public bool Equals(Point2D other)
-        {
-            //// ReSharper disable CompareOfFloatsByEqualityOperator
-            return this.X == other.X && this.Y == other.Y;
-            //// ReSharper restore CompareOfFloatsByEqualityOperator
-        }
-
         /// <summary>
         /// Returns a value to indicate if a pair of points are equal
         /// </summary>
@@ -423,25 +414,15 @@ namespace MathNet.Spatial.Euclidean
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return obj is Point2D p && this.Equals(p);
-        }
+        public bool Equals(Point2D other) => this.X.Equals(other.X) && this.Y.Equals(other.Y);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (this.X.GetHashCode() * 397) ^ this.Y.GetHashCode();
-            }
-        }
+        public override bool Equals(object obj) => obj is Point2D p && this.Equals(p);
+
+        /// <inheritdoc />
+        [Pure]
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema() => null;

--- a/src/Spatial/Euclidean/Polygon2D.cs
+++ b/src/Spatial/Euclidean/Polygon2D.cs
@@ -133,6 +133,28 @@
         }
 
         /// <summary>
+        /// Returns a value that indicates whether each point in two specified polygons is equal.
+        /// </summary>
+        /// <param name="left">The first polygon to compare</param>
+        /// <param name="right">The second polygon to compare</param>
+        /// <returns>True if the polygons are the same; otherwise false.</returns>
+        public static bool operator ==(Polygon2D left, Polygon2D right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether any point in two specified polygons is not equal.
+        /// </summary>
+        /// <param name="left">The first polygon to compare</param>
+        /// <param name="right">The second polygon to compare</param>
+        /// <returns>True if the polygons are different; otherwise false.</returns>
+        public static bool operator !=(Polygon2D left, Polygon2D right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
         /// Compute whether or not two polygons are colliding based on whether or not the vertices of
         /// either are enclosed within the shape of the other. This is a simple means of detecting collisions
         /// that can fail if the two polygons are heavily overlapped in such a way that one protrudes through
@@ -143,7 +165,7 @@
         /// <returns>True if the vertices collide; otherwise false.</returns>
         public static bool ArePolygonVerticesColliding(Polygon2D a, Polygon2D b)
         {
-            return a.Any(b.EnclosesPoint) || b.Any(a.EnclosesPoint);
+            return a.points.Any(b.EnclosesPoint) || b.points.Any(a.EnclosesPoint);
         }
 
         /// <summary>
@@ -314,21 +336,6 @@
             return this.GetEnumerator();
         }
 
-        /// <inheritdoc />
-        [Pure]
-        public bool Equals(Polygon2D other)
-        {
-            for (var i = 0; i < this.points.Count; i++)
-            {
-                if (this.points[i] != other.points[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
         /// <summary>
         /// Returns a value to indicate if a pair of polygons are equal
         /// </summary>
@@ -338,6 +345,11 @@
         [Pure]
         public bool Equals(Polygon2D other, double tolerance)
         {
+            if (this.VertexCount != other.VertexCount)
+            {
+                return false;
+            }
+
             for (var i = 0; i < this.points.Count; i++)
             {
                 if (!this.points[i].Equals(other.points[i], tolerance))
@@ -351,9 +363,29 @@
 
         /// <inheritdoc />
         [Pure]
+        public bool Equals(Polygon2D other)
+        {
+            if (this.VertexCount != other.VertexCount)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < this.points.Count; i++)
+            {
+                if (!this.points[i].Equals(other.points[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        [Pure]
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }
@@ -365,7 +397,17 @@
         [Pure]
         public override int GetHashCode()
         {
-            return this.Vertices.GetHashCode();
+            unchecked
+            {
+                int hashcode = 0;
+                for (var i = 0; i < this.points.Count; i++)
+                {
+                    // HashCode.Combine(single) is partially diffuse so should be ok for this.
+                    hashcode += HashCode.Combine(this.points[i]);
+                }
+
+                return hashcode;
+            }
         }
 
         /// <summary>

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -534,15 +534,6 @@
             return Vector<double>.Build.Dense(new[] { this.X, this.Y });
         }
 
-        /// <inheritdoc />
-        [Pure]
-        public bool Equals(Vector2D other)
-        {
-            //// ReSharper disable CompareOfFloatsByEqualityOperator
-            return this.X == other.X && this.Y == other.Y;
-            //// ReSharper restore CompareOfFloatsByEqualityOperator
-        }
-
         /// <summary>
         /// Compare this instance with <paramref name="other"/>
         /// </summary>
@@ -563,25 +554,15 @@
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return obj is Vector2D v && this.Equals(v);
-        }
+        public bool Equals(Vector2D other) => this.X.Equals(other.X) && this.Y.Equals(other.Y);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (this.X.GetHashCode() * 397) ^ this.Y.GetHashCode();
-            }
-        }
+        public override bool Equals(object obj) => obj is Vector2D v && this.Equals(v);
+
+        /// <inheritdoc />
+        [Pure]
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y);
 
         /// <inheritdoc />
         [Pure]

--- a/src/Spatial/Internals/HashCode.cs
+++ b/src/Spatial/Internals/HashCode.cs
@@ -1,0 +1,439 @@
+﻿namespace MathNet.Spatial.Internals
+{
+    // The contents of this file is taken from https://github.com/dotnet/coreclr/blob/master/src/mscorlib/shared/System/HashCode.cs
+    // To be replaced by the framework implementation when released for the appropriate builds
+#pragma warning disable SA1203, SA1101, SA1600, SA1512, SA1515, SA1503, SA1028, SA1308, SA1512, SA1202, SA1311, SA1028, SA1132, SA1309, SA1108, SA1520
+
+    // Licensed to the .NET Foundation under one or more agreements.
+    // The .NET Foundation licenses this file to you under the MIT license.
+    // See the LICENSE file in the project root for more information.
+
+    /*
+
+    The xxHash32 implementation is based on the code published by Yann Collet:
+    https://raw.githubusercontent.com/Cyan4973/xxHash/5c174cfa4e45a42f94082dc0d4539b39696afea1/xxhash.c
+
+      xxHash - Fast Hash algorithm
+      Copyright (C) 2012-2016, Yann Collet
+
+      BSD 2-Clause License (http://www.opensource.org/licenses/bsd-license.php)
+
+      Redistribution and use in source and binary forms, with or without
+      modification, are permitted provided that the following conditions are
+      met:
+
+      * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following disclaimer
+      in the documentation and/or other materials provided with the
+      distribution.
+
+      THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+      A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+      OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+      LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+      DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+      (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+      OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+      You can contact the author at :
+      - xxHash homepage: http://www.xxhash.com
+      - xxHash source repository : https://github.com/Cyan4973/xxHash
+
+    */
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.CompilerServices;
+
+    // xxHash32 is used for the hash code.
+    // https://github.com/Cyan4973/xxHash
+
+    /// <summary>
+    /// Generates a hashcode
+    /// </summary>
+    internal struct HashCode
+    {
+        private static readonly uint s_seed = GenerateGlobalSeed();
+
+        private const uint Prime1 = 2654435761U;
+        private const uint Prime2 = 2246822519U;
+        private const uint Prime3 = 3266489917U;
+        private const uint Prime4 = 668265263U;
+        private const uint Prime5 = 374761393U;
+
+        private uint _v1, _v2, _v3, _v4;
+        private uint _queue1, _queue2, _queue3;
+        private uint _length;
+
+        private static uint GenerateGlobalSeed()
+        {
+            // NOTE: Modified from original unsafe implementation. Might be better to use a more random seed.
+            Random r = new Random();
+            int seed = r.Next();
+            return unchecked((uint)seed);
+        }
+
+        public static int Combine<T1>(T1 value1)
+        {
+            // Provide a way of diffusing bits from something with a limited
+            // input hash space. For example, many enums only have a few
+            // possible hashes, only using the bottom few bits of the code. Some
+            // collections are built on the assumption that hashes are spread
+            // over a larger space, so diffusing the bits may help the
+            // collection work more efficiently.
+
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+
+            uint hash = MixEmptyState();
+            hash += 4;
+
+            hash = QueueRound(hash, hc1);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2>(T1 value1, T2 value2)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+
+            uint hash = MixEmptyState();
+            hash += 8;
+
+            hash = QueueRound(hash, hc1);
+            hash = QueueRound(hash, hc2);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3>(T1 value1, T2 value2, T3 value3)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+
+            uint hash = MixEmptyState();
+            hash += 12;
+
+            hash = QueueRound(hash, hc1);
+            hash = QueueRound(hash, hc2);
+            hash = QueueRound(hash, hc3);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4>(T1 value1, T2 value2, T3 value3, T4 value4)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 16;
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 20;
+
+            hash = QueueRound(hash, hc5);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+            var hc6 = (uint)(value6?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 24;
+
+            hash = QueueRound(hash, hc5);
+            hash = QueueRound(hash, hc6);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+            var hc6 = (uint)(value6?.GetHashCode() ?? 0);
+            var hc7 = (uint)(value7?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 28;
+
+            hash = QueueRound(hash, hc5);
+            hash = QueueRound(hash, hc6);
+            hash = QueueRound(hash, hc7);
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        public static int Combine<T1, T2, T3, T4, T5, T6, T7, T8>(T1 value1, T2 value2, T3 value3, T4 value4, T5 value5, T6 value6, T7 value7, T8 value8)
+        {
+            var hc1 = (uint)(value1?.GetHashCode() ?? 0);
+            var hc2 = (uint)(value2?.GetHashCode() ?? 0);
+            var hc3 = (uint)(value3?.GetHashCode() ?? 0);
+            var hc4 = (uint)(value4?.GetHashCode() ?? 0);
+            var hc5 = (uint)(value5?.GetHashCode() ?? 0);
+            var hc6 = (uint)(value6?.GetHashCode() ?? 0);
+            var hc7 = (uint)(value7?.GetHashCode() ?? 0);
+            var hc8 = (uint)(value8?.GetHashCode() ?? 0);
+
+            Initialize(out uint v1, out uint v2, out uint v3, out uint v4);
+
+            v1 = Round(v1, hc1);
+            v2 = Round(v2, hc2);
+            v3 = Round(v3, hc3);
+            v4 = Round(v4, hc4);
+
+            v1 = Round(v1, hc5);
+            v2 = Round(v2, hc6);
+            v3 = Round(v3, hc7);
+            v4 = Round(v4, hc8);
+
+            uint hash = MixState(v1, v2, v3, v4);
+            hash += 32;
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+        // [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Rol(uint value, int count)
+            => (value << count) | (value >> (32 - count));
+
+        // [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void Initialize(out uint v1, out uint v2, out uint v3, out uint v4)
+        {
+            v1 = s_seed + Prime1 + Prime2;
+            v2 = s_seed + Prime2;
+            v3 = s_seed;
+            v4 = s_seed - Prime1;
+        }
+
+        // [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint Round(uint hash, uint input)
+        {
+            hash += input * Prime2;
+            hash = Rol(hash, 13);
+            hash *= Prime1;
+            return hash;
+        }
+
+        // [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint QueueRound(uint hash, uint queuedValue)
+        {
+            hash += queuedValue * Prime3;
+            return Rol(hash, 17) * Prime4;
+        }
+
+        // [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint MixState(uint v1, uint v2, uint v3, uint v4)
+        {
+            return Rol(v1, 1) + Rol(v2, 7) + Rol(v3, 12) + Rol(v4, 18);
+        }
+
+        private static uint MixEmptyState()
+        {
+            return s_seed + Prime5;
+        }
+
+        // [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint MixFinal(uint hash)
+        {
+            hash ^= hash >> 15;
+            hash *= Prime2;
+            hash ^= hash >> 13;
+            hash *= Prime3;
+            hash ^= hash >> 16;
+            return hash;
+        }
+
+        public void Add<T>(T value)
+        {
+            Add(value?.GetHashCode() ?? 0);
+        }
+
+        public void Add<T>(T value, IEqualityComparer<T> comparer)
+        {
+            Add(comparer != null ? comparer.GetHashCode(value) : (value?.GetHashCode() ?? 0));
+        }
+
+        private void Add(int value)
+        {
+            // The original xxHash works as follows:
+            // 0. Initialize immediately. We can't do this in a struct (no
+            //    default ctor).
+            // 1. Accumulate blocks of length 16 (4 uints) into 4 accumulators.
+            // 2. Accumulate remaining blocks of length 4 (1 uint) into the
+            //    hash.
+            // 3. Accumulate remaining blocks of length 1 into the hash.
+
+            // There is no need for #3 as this type only accepts ints. _queue1,
+            // _queue2 and _queue3 are basically a buffer so that when
+            // ToHashCode is called we can execute #2 correctly.
+
+            // We need to initialize the xxHash32 state (_v1 to _v4) lazily (see
+            // #0) nd the last place that can be done if you look at the
+            // original code is just before the first block of 16 bytes is mixed
+            // in. The xxHash32 state is never used for streams containing fewer
+            // than 16 bytes.
+
+            // To see what's really going on here, have a look at the Combine
+            // methods.
+
+            var val = (uint)value;
+
+            // Storing the value of _length locally shaves of quite a few bytes
+            // in the resulting machine code.
+            uint previousLength = _length++;
+            uint position = previousLength % 4;
+
+            // Switch can't be inlined.
+
+            if (position == 0)
+                _queue1 = val;
+            else if (position == 1)
+                _queue2 = val;
+            else if (position == 2)
+                _queue3 = val;
+            else // position == 3
+            {
+                if (previousLength == 3)
+                    Initialize(out _v1, out _v2, out _v3, out _v4);
+
+                _v1 = Round(_v1, _queue1);
+                _v2 = Round(_v2, _queue2);
+                _v3 = Round(_v3, _queue3);
+                _v4 = Round(_v4, val);
+            }
+        }
+
+        public int ToHashCode()
+        {
+            // Storing the value of _length locally shaves of quite a few bytes
+            // in the resulting machine code.
+            uint length = _length;
+
+            // position refers to the *next* queue position in this method, so
+            // position == 1 means that _queue1 is populated; _queue2 would have
+            // been populated on the next call to Add.
+            uint position = length % 4;
+
+            // If the length is less than 4, _v1 to _v4 don't contain anything
+            // yet. xxHash32 treats this differently.
+
+            uint hash = length < 4 ? MixEmptyState() : MixState(_v1, _v2, _v3, _v4);
+
+            // _length is incremented once per Add(Int32) and is therefore 4
+            // times too small (xxHash length is in bytes, not ints).
+
+            hash += length * 4;
+
+            // Mix what remains in the queue
+
+            // Switch can't be inlined right now, so use as few branches as
+            // possible by manually excluding impossible scenarios (position > 1
+            // is always false if position is not > 0).
+            if (position > 0)
+            {
+                hash = QueueRound(hash, _queue1);
+                if (position > 1)
+                {
+                    hash = QueueRound(hash, _queue2);
+                    if (position > 2)
+                        hash = QueueRound(hash, _queue3);
+                }
+            }
+
+            hash = MixFinal(hash);
+            return (int)hash;
+        }
+
+#pragma warning disable 0809
+        // Obsolete member 'memberA' overrides non-obsolete member 'memberB'. 
+        // Disallowing GetHashCode and Equals is by design
+
+        // * We decided to not override GetHashCode() to produce the hash code 
+        //   as this would be weird, both naming-wise as well as from a
+        //   behavioral standpoint (GetHashCode() should return the object's
+        //   hash code, not the one being computed).
+
+        // * Even though ToHashCode() can be called safely multiple times on
+        //   this implementation, it is not part of the contract. If the
+        //   implementation has to change in the future we don't want to worry
+        //   about people who might have incorrectly used this type.
+
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes. Use ToHashCode to retrieve the computed hash code.", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => throw new NotSupportedException("GetHasCode not supported");
+
+        [Obsolete("HashCode is a mutable struct and should not be compared with other HashCodes.", error: true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => throw new NotSupportedException("Equals is not supported");
+#pragma warning restore 0809
+    }
+}


### PR DESCRIPTION
All listed types now consistently implement:
Equals<T>
override Equals(object)
GetHashCode  - using internal HashCode struct
Equals<T>(T, double tolerance)
Operator overrides for == and !=
