### PR TITLE
Equality alignment for remaining entities

### DIFF
--- a/src/Spatial/Euclidean/Circle3D.cs
+++ b/src/Spatial/Euclidean/Circle3D.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics.Contracts;
+    using MathNet.Spatial.Internals;
 
     /// <summary>
     /// Describes a 3 dimensional circle
@@ -153,38 +154,40 @@
             return new Circle3D(cp, axis, cp.DistanceTo(p1));
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns a value to indicate if a pair of circles are equal
+        /// </summary>
+        /// <param name="c">The circle to compare against.</param>
+        /// <param name="tolerance">A tolerance (epsilon) to adjust for floating point error</param>
+        /// <returns>true if the points are equal; otherwise false</returns>
         [Pure]
-        public bool Equals(Circle3D other)
+        public bool Equals(Circle3D c, double tolerance)
         {
-            return this.CenterPoint.Equals(other.CenterPoint)
-                   && this.Axis.Equals(other.Axis)
-                   && this.Radius.Equals(other.Radius);
-        }
-
-        /// <inheritdoc />
-        [Pure]
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
+            if (tolerance < 0)
             {
-                return false;
+                throw new ArgumentException("epsilon < 0");
             }
 
-            return obj is Circle3D d && this.Equals(d);
+            return Math.Abs(c.Radius - this.Radius) < tolerance
+                && this.Axis.Equals(c.Axis, tolerance)
+                && this.CenterPoint.Equals(c.CenterPoint, tolerance);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode()
+        public bool Equals(Circle3D c)
         {
-            unchecked
-            {
-                var hashCode = this.CenterPoint.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Axis.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Radius.GetHashCode();
-                return hashCode;
-            }
+            return this.CenterPoint.Equals(c.CenterPoint)
+                   && this.Axis.Equals(c.Axis)
+                   && this.Radius.Equals(c.Radius);
         }
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool Equals(object obj) => obj is Circle3D c && this.Equals(c);
+
+        /// <inheritdoc />
+        [Pure]
+        public override int GetHashCode() => HashCode.Combine(this.CenterPoint, this.Axis, this.Radius);
     }
 }

--- a/src/Spatial/Euclidean/EulerAngles.cs
+++ b/src/Spatial/Euclidean/EulerAngles.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Diagnostics.Contracts;
     using MathNet.Numerics;
+    using MathNet.Spatial.Internals;
     using MathNet.Spatial.Units;
 
     /// <summary>
@@ -73,42 +74,51 @@
         }
 
         /// <summary>
-        /// Compares two <see cref="EulerAngles"/>
+        /// Returns a value to indicate if this EulerAngles is equivelent to a given EulerAngles
         /// </summary>
-        /// <param name="other">the other <see cref="EulerAngles"/> to compare</param>
-        /// <returns>true if the angles are equal to within a fixed error of 0.000001</returns>
+        /// <param name="other">The EulerAngles to compare against.</param>
+        /// <param name="tolerance">A tolerance (epsilon) to adjust for floating point error</param>
+        /// <returns>true if the EulerAngles are equal; otherwise false</returns>
+        [Pure]
+        public bool Equals(EulerAngles other, double tolerance)
+        {
+            if (tolerance < 0)
+            {
+                throw new ArgumentException("epsilon < 0");
+            }
+
+            return this.Alpha.Equals(other.Alpha, tolerance) &&
+                   this.Beta.Equals(other.Beta, tolerance) &&
+                   this.Gamma.Equals(other.Gamma, tolerance);
+        }
+
+        /// <summary>
+        /// Returns a value to indicate if this EulerAngles is equivelent to a given EulerAngles
+        /// </summary>
+        /// <param name="other">The EulerAngles to compare against.</param>
+        /// <param name="tolerance">A tolerance (epsilon) to adjust for floating point error</param>
+        /// <returns>true if the EulerAngles are equal; otherwise false</returns>
+        [Pure]
+        public bool Equals(EulerAngles other, Angle tolerance)
+        {
+            return this.Alpha.Equals(other.Alpha, tolerance) &&
+                   this.Beta.Equals(other.Beta, tolerance) &&
+                   this.Gamma.Equals(other.Gamma, tolerance);
+        }
+
+        /// <inheritdoc/>
         [Pure]
         public bool Equals(EulerAngles other)
         {
-            const double DefaultAbsoluteError = 0.000001;
-            return this.Alpha.Radians.AlmostEqual(other.Alpha.Radians, DefaultAbsoluteError) &&
-                   this.Beta.Radians.AlmostEqual(other.Beta.Radians, DefaultAbsoluteError) &&
-                   this.Gamma.Radians.AlmostEqual(other.Gamma.Radians, DefaultAbsoluteError);
+            return this.Alpha.Equals(other.Alpha) && this.Beta.Equals(other.Beta) && this.Gamma.Equals(other.Gamma);
         }
 
         /// <inheritdoc/>
         [Pure]
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return obj is EulerAngles angles && this.Equals(angles);
-        }
+        public override bool Equals(object obj) => obj is EulerAngles angles && this.Equals(angles);
 
         /// <inheritdoc/>
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = this.Alpha.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Beta.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Gamma.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(this.Alpha, this.Beta, this.Gamma);
     }
 }

--- a/src/Spatial/Euclidean/LineSegment3D.cs
+++ b/src/Spatial/Euclidean/LineSegment3D.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics.Contracts;
+    using MathNet.Spatial.Internals;
     using MathNet.Spatial.Units;
 
     /// <summary>
@@ -238,32 +239,15 @@
 
         /// <inheritdoc/>
         [Pure]
-        public bool Equals(LineSegment3D other)
-        {
-            return this.StartPoint.Equals(other.StartPoint) && this.EndPoint.Equals(other.EndPoint);
-        }
+        public bool Equals(LineSegment3D l) => this.StartPoint.Equals(l.StartPoint) && this.EndPoint.Equals(l.EndPoint);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj)
-        {
-            if (obj is null)
-            {
-                return false;
-            }
-
-            return obj is LineSegment3D d && this.Equals(d);
-        }
+        public override bool Equals(object obj) => obj is LineSegment3D l && this.Equals(l);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return (this.StartPoint.GetHashCode() * 397) ^ this.EndPoint.GetHashCode();
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(this.StartPoint, this.EndPoint);
 
         /// <summary>
         /// Extends the segment to a infinite line and finds the closest point on that line to the provided point.

--- a/src/Spatial/Euclidean/Plane.cs
+++ b/src/Spatial/Euclidean/Plane.cs
@@ -108,11 +108,23 @@
         /// </summary>
         public Point3D RootPoint => (-this.D * this.Normal).ToPoint3D();
 
+        /// <summary>
+        /// Returns a value that indicates whether each pair of elements in two specified geometric planes is equal.
+        /// </summary>
+        /// <param name="left">The first plane to compare.</param>
+        /// <param name="right">The second plane to compare.</param>
+        /// <returns>True if the geometric planes are the same; otherwise false.</returns>
         public static bool operator ==(Plane left, Plane right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>
+        /// Returns a value that indicates whether any pair of elements in two specified geometric planes is not equal.
+        /// </summary>
+        /// <param name="left">The first plane to compare.</param>
+        /// <param name="right">The second plane to compare.</param>
+        /// <returns>True if the geometric planes are different; otherwise false.</returns>
         public static bool operator !=(Plane left, Plane right)
         {
             return !left.Equals(right);
@@ -453,38 +465,34 @@
             return new Plane(rotatedPlaneVector, rotatedPoint);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns a value to indicate if a pair of geometric planes are equal
+        /// </summary>
+        /// <param name="other">The geometric plane to compare against.</param>
+        /// <param name="tolerance">A tolerance (epsilon) to adjust for floating point error</param>
+        /// <returns>true if the geometric planes are equal; otherwise false</returns>
         [Pure]
-        public bool Equals(Plane other)
+        public bool Equals(Plane other, double tolerance)
         {
-            return this.RootPoint == other.RootPoint && this.Normal == other.Normal;
-        }
-
-        /// <inheritdoc />
-        [Pure]
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
+            if (tolerance < 0)
             {
-                return false;
+                throw new ArgumentException("epsilon < 0");
             }
 
-            return obj is Plane && this.Equals((Plane)obj);
+            return Math.Abs(other.D - this.D) < tolerance && this.Normal.Equals(other.Normal, tolerance);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var result = this.A.GetHashCode();
-                result = (result * 397) ^ this.C.GetHashCode();
-                result = (result * 397) ^ this.B.GetHashCode();
-                result = (result * 397) ^ this.D.GetHashCode();
-                return result;
-            }
-        }
+        public bool Equals(Plane p) => this.D.Equals(p.D) && this.Normal.Equals(p.Normal);
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool Equals(object obj) => obj is Plane p && this.Equals(p);
+
+        /// <inheritdoc />
+        [Pure]
+        public override int GetHashCode() => HashCode.Combine(this.Normal, this.D);
 
         /// <inheritdoc />
         [Pure]

--- a/src/Spatial/Euclidean/Point3D.cs
+++ b/src/Spatial/Euclidean/Point3D.cs
@@ -453,16 +453,6 @@ namespace MathNet.Spatial.Euclidean
             return string.Format("({0}{1} {2}{1} {3})", this.X.ToString(format, numberFormatInfo), separator, this.Y.ToString(format, numberFormatInfo), this.Z.ToString(format, numberFormatInfo));
         }
 
-        /// <inheritdoc />
-        [Pure]
-        public bool Equals(Point3D other)
-        {
-            // ReSharper disable CompareOfFloatsByEqualityOperator
-            return this.X == other.X && this.Y == other.Y && this.Z == other.Z;
-
-            // ReSharper restore CompareOfFloatsByEqualityOperator
-        }
-
         /// <summary>
         /// Returns a value to indicate if a pair of points are equal
         /// </summary>
@@ -484,28 +474,18 @@ namespace MathNet.Spatial.Euclidean
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj)
+        public bool Equals(Point3D other)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return obj is Point3D && this.Equals((Point3D)obj);
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = this.X.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override bool Equals(object obj) => obj is Point3D p && this.Equals(p);
+
+        /// <inheritdoc />
+        [Pure]
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema() => null;

--- a/src/Spatial/Euclidean/Quaternion.cs
+++ b/src/Spatial/Euclidean/Quaternion.cs
@@ -1,6 +1,8 @@
 ﻿namespace MathNet.Spatial.Euclidean
 {
     using System;
+    using System.Diagnostics.Contracts;
+    using MathNet.Spatial.Internals;
     using Numerics;
     using Numerics.LinearAlgebra.Double;
     using Units;
@@ -364,12 +366,12 @@
         /// <summary>
         /// Equality operator for two quaternions
         /// </summary>
-        /// <param name="q1">The first quaternion</param>
-        /// <param name="q2">The second quaternion</param>
+        /// <param name="left">The first quaternion</param>
+        /// <param name="right">The second quaternion</param>
         /// <returns>True if the quaternions are equal; otherwise false</returns>
-        public static bool operator ==(Quaternion q1, Quaternion q2)
+        public static bool operator ==(Quaternion left, Quaternion right)
         {
-            return q1.Equals(q2);
+            return left.Equals(right);
         }
 
         /// <summary>
@@ -403,12 +405,12 @@
         /// <summary>
         /// Inequality operator for two quaternions
         /// </summary>
-        /// <param name="q1">The first quaternion</param>
-        /// <param name="q2">The second quaternion</param>
+        /// <param name="left">The first quaternion</param>
+        /// <param name="right">The second quaternion</param>
         /// <returns>True if the quaternions are different; otherwise false</returns>
-        public static bool operator !=(Quaternion q1, Quaternion q2)
+        public static bool operator !=(Quaternion left, Quaternion right)
         {
-            return !(q1 == q2);
+            return !left.Equals(right);
         }
 
         /// <summary>
@@ -720,7 +722,29 @@
                 this.ImagZ);
         }
 
+        /// <summary>
+        /// Returns a value to indicate if this vector is equivelent to a given unit vector
+        /// </summary>
+        /// <param name="other">The unit vector to compare against.</param>
+        /// <param name="tolerance">A tolerance (epsilon) to adjust for floating point error</param>
+        /// <returns>true if the vectors are equal; otherwise false</returns>
+        [Pure]
+        public bool Equals(Quaternion other, double tolerance)
+        {
+            if ((other.IsNan && this.IsNan) ||
+                (other.IsInfinity && this.IsInfinity))
+            {
+                return true;
+            }
+
+            return Math.Abs(other.w - this.w) < tolerance
+                && Math.Abs(other.x - this.x) < tolerance
+                && Math.Abs(other.y - this.y) < tolerance
+                && Math.Abs(other.z - this.z) < tolerance;
+        }
+
         /// <inheritdoc />
+        [Pure]
         public bool Equals(Quaternion other)
         {
             if ((other.IsNan && this.IsNan) ||
@@ -729,35 +753,19 @@
                 return true;
             }
 
-            return this.Real.AlmostEqual(other.Real)
-                && this.ImagX.AlmostEqual(other.ImagX)
-                && this.ImagY.AlmostEqual(other.ImagY)
-                && this.ImagZ.AlmostEqual(other.ImagZ);
+            return this.w.Equals(other.w)
+                && this.x.Equals(other.x)
+                && this.y.Equals(other.y)
+                && this.z.Equals(other.z);
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return obj is Quaternion && this.Equals((Quaternion)obj);
-        }
+        [Pure]
+        public override bool Equals(object obj) => obj is Quaternion q && this.Equals(q);
 
         /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = this.w.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.x.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.y.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.z.GetHashCode();
-                return hashCode;
-            }
-        }
+        [Pure]
+        public override int GetHashCode() => HashCode.Combine(this.w, this.x, this.y, this.z);
 
         /// <summary>
         /// Calculates norm of quaternion from it's algebraical notation

--- a/src/Spatial/Euclidean/Ray3D.cs
+++ b/src/Spatial/Euclidean/Ray3D.cs
@@ -154,14 +154,6 @@ namespace MathNet.Spatial.Euclidean
             return this.Direction.IsParallelTo(otherRay.Direction, tolerance);
         }
 
-        /// <inheritdoc/>
-        [Pure]
-        public bool Equals(Ray3D other)
-        {
-            return this.Direction.Equals(other.Direction) &&
-                   this.ThroughPoint.Equals(other.ThroughPoint);
-        }
-
         /// <summary>
         /// Returns a value to indicate if a pair of rays are equal
         /// </summary>
@@ -177,27 +169,15 @@ namespace MathNet.Spatial.Euclidean
 
         /// <inheritdoc/>
         [Pure]
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return obj is Ray3D d && this.Equals(d);
-        }
+        public bool Equals(Ray3D r) => this.Direction.Equals(r.Direction) && this.ThroughPoint.Equals(r.ThroughPoint);
 
         /// <inheritdoc/>
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = this.ThroughPoint.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Direction.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override bool Equals(object obj) => obj is Ray3D r && this.Equals(r);
+
+        /// <inheritdoc/>
+        [Pure]
+        public override int GetHashCode() => HashCode.Combine(this.ThroughPoint, this.Direction);
 
         /// <inheritdoc/>
         [Pure]

--- a/src/Spatial/Euclidean/UnitVector3D.cs
+++ b/src/Spatial/Euclidean/UnitVector3D.cs
@@ -847,26 +847,6 @@ namespace MathNet.Spatial.Euclidean
             return string.Format("({0}{1} {2}{1} {3})", this.X.ToString(format, numberFormatInfo), separator, this.Y.ToString(format, numberFormatInfo), this.Z.ToString(format, numberFormatInfo));
         }
 
-        /// <inheritdoc />
-        [Pure]
-        public bool Equals(Vector3D other)
-        {
-            // ReSharper disable CompareOfFloatsByEqualityOperator
-            return this.X == other.X && this.Y == other.Y && this.Z == other.Z;
-
-            // ReSharper restore CompareOfFloatsByEqualityOperator
-        }
-
-        /// <inheritdoc />
-        [Pure]
-        public bool Equals(UnitVector3D other)
-        {
-            // ReSharper disable CompareOfFloatsByEqualityOperator
-            return this.X == other.X && this.Y == other.Y && this.Z == other.Z;
-
-            // ReSharper restore CompareOfFloatsByEqualityOperator
-        }
-
         /// <summary>
         /// Returns a value to indicate if a pair of vectors are equal
         /// </summary>
@@ -907,29 +887,28 @@ namespace MathNet.Spatial.Euclidean
 
         /// <inheritdoc />
         [Pure]
+        public bool Equals(Vector3D other)
+        {
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
+        }
+
+        /// <inheritdoc />
+        [Pure]
+        public bool Equals(UnitVector3D other)
+        {
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
+        }
+
+        /// <inheritdoc />
+        [Pure]
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return (obj is UnitVector3D && this.Equals((UnitVector3D)obj)) ||
-                   (obj is Vector3D && this.Equals((Vector3D)obj));
+            return (obj is UnitVector3D u && this.Equals(u)) || (obj is Vector3D v && this.Equals(v));
         }
 
         /// <inheritdoc/>
         [Pure]
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = this.X.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema()

--- a/src/Spatial/Euclidean/Vector3D.cs
+++ b/src/Spatial/Euclidean/Vector3D.cs
@@ -681,26 +681,6 @@ namespace MathNet.Spatial.Euclidean
                 this.Z.ToString(format, numberFormatInfo));
         }
 
-        /// <inheritdoc />
-        [Pure]
-        public bool Equals(Vector3D other)
-        {
-            // ReSharper disable CompareOfFloatsByEqualityOperator
-            return this.X == other.X && this.Y == other.Y && this.Z == other.Z;
-
-            // ReSharper restore CompareOfFloatsByEqualityOperator
-        }
-
-        /// <inheritdoc />
-        [Pure]
-        public bool Equals(UnitVector3D other)
-        {
-            // ReSharper disable CompareOfFloatsByEqualityOperator
-            return this.X == other.X && this.Y == other.Y && this.Z == other.Z;
-
-            // ReSharper restore CompareOfFloatsByEqualityOperator
-        }
-
         /// <summary>
         /// Returns a value to indicate if a pair of vectors are equal
         /// </summary>
@@ -741,29 +721,28 @@ namespace MathNet.Spatial.Euclidean
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj)
+        public bool Equals(Vector3D other)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return (obj is UnitVector3D && this.Equals((UnitVector3D)obj)) ||
-                   (obj is Vector3D && this.Equals((Vector3D)obj));
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode()
+        public bool Equals(UnitVector3D other)
         {
-            unchecked
-            {
-                var hashCode = this.X.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
-                return hashCode;
-            }
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
         }
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool Equals(object obj)
+        {
+            return (obj is UnitVector3D u && this.Equals(u)) || (obj is Vector3D v && this.Equals(v));
+        }
+
+        /// <inheritdoc />
+        [Pure]
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema()

--- a/src/Spatial/Projective/Point3DHomogeneous.cs
+++ b/src/Spatial/Projective/Point3DHomogeneous.cs
@@ -4,11 +4,12 @@
     using System.Globalization;
     using MathNet.Numerics.LinearAlgebra;
     using MathNet.Spatial.Euclidean;
+    using MathNet.Spatial.Internals;
 
     /// <summary>
     /// A Point3DHomogeneous struct
     /// </summary>
-    internal struct Point3DHomogeneous
+    internal struct Point3DHomogeneous : IEquatable<Point3DHomogeneous>
     {
         /// <summary>
         /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
@@ -64,6 +65,28 @@
         public static Point3DHomogeneous NaN => new Point3DHomogeneous(double.NaN, double.NaN, double.NaN, double.NaN);
 
         /// <summary>
+        /// Returns a value that indicates whether each pair of elements in two specified points is equal.
+        /// </summary>
+        /// <param name="left">The first point to compare.</param>
+        /// <param name="right">The second point to compare.</param>
+        /// <returns>True if the points are the same; otherwise false.</returns>
+        public static bool operator ==(Point3DHomogeneous left, Point3DHomogeneous right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether any pair of elements in two specified points is not equal.
+        /// </summary>
+        /// <param name="left">The first point to compare.</param>
+        /// <param name="right">The second point to compare.</param>
+        /// <returns>True if the points are different; otherwise false.</returns>
+        public static bool operator !=(Point3DHomogeneous left, Point3DHomogeneous right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
         /// Create a new Point3DHomogeneous from a Math.NET Numerics vector of length 4.
         /// </summary>
         /// <param name="vector"> A vector with length 4 to populate the created instance with.</param>
@@ -106,18 +129,6 @@
         /// Returns a value to indicate if a pair of Point3DHomogeneous are equal
         /// </summary>
         /// <param name="other">The Point3DHomogeneous to compare against.</param>
-        /// <returns>True if the Point3DHomogeneouses are equal; otherwise false</returns>
-        public bool Equals(Point3DHomogeneous other)
-        {
-            //// ReSharper disable CompareOfFloatsByEqualityOperator
-            return this.X == other.X && this.Y == other.Y && this.Z == other.Z && this.W == other.W;
-            //// ReSharper restore CompareOfFloatsByEqualityOperator
-        }
-
-        /// <summary>
-        /// Returns a value to indicate if a pair of Point3DHomogeneous are equal
-        /// </summary>
-        /// <param name="other">The Point3DHomogeneous to compare against.</param>
         /// <param name="tolerance">A tolerance (epsilon) to adjust for floating point error</param>
         /// <returns>True if the Point3DHomogeneouses are equal; otherwise false</returns>
         public bool Equals(Point3DHomogeneous other, double tolerance)
@@ -134,28 +145,16 @@
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public bool Equals(Point3DHomogeneous other)
         {
-            if (obj is null)
-            {
-                return false;
-            }
-
-            return obj is Point3DHomogeneous homogeneous && this.Equals(homogeneous);
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z) && this.W.Equals(other.W);
         }
 
         /// <inheritdoc/>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = this.X.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.W.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override bool Equals(object obj) => obj is Point3DHomogeneous p && this.Equals(p);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z, this.W);
 
         /// <summary>
         /// Gets a vector3D

--- a/src/Spatial/Projective/Vector3DHomogeneous.cs
+++ b/src/Spatial/Projective/Vector3DHomogeneous.cs
@@ -4,11 +4,12 @@
     using System.Globalization;
     using MathNet.Numerics.LinearAlgebra;
     using MathNet.Spatial.Euclidean;
+    using MathNet.Spatial.Internals;
 
     /// <summary>
     /// A Vector3DHomogeneous struct
     /// </summary>
-    internal struct Vector3DHomogeneous
+    internal struct Vector3DHomogeneous : IEquatable<Vector3DHomogeneous>
     {
         /// <summary>
         /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
@@ -64,6 +65,28 @@
         public static Vector3DHomogeneous NaN => new Vector3DHomogeneous(double.NaN, double.NaN, double.NaN, double.NaN);
 
         /// <summary>
+        /// Returns a value that indicates whether each pair of elements in two specified vectors is equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if the vectors are the same; otherwise false.</returns>
+        public static bool operator ==(Vector3DHomogeneous left, Vector3DHomogeneous right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Returns a value that indicates whether any pair of elements in two specified vectors is not equal.
+        /// </summary>
+        /// <param name="left">The first vector to compare.</param>
+        /// <param name="right">The second vector to compare.</param>
+        /// <returns>True if the vectors are different; otherwise false.</returns>
+        public static bool operator !=(Vector3DHomogeneous left, Vector3DHomogeneous right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
         /// Create a new Vector3DHomogeneous from a Math.NET Numerics vector of length 4.
         /// </summary>
         /// <param name="vector"> A vector with length 4 to populate the created instance with.</param>
@@ -112,18 +135,6 @@
         /// Returns a value to indicate if a pair of Vector3DHomogeneous are equal
         /// </summary>
         /// <param name="other">The Vector3DHomogeneous to compare against.</param>
-        /// <returns>True if the Vector3DHomogeneouses are equal; otherwise false</returns>
-        public bool Equals(Vector3DHomogeneous other)
-        {
-            //// ReSharper disable CompareOfFloatsByEqualityOperator
-            return this.X == other.X && this.Y == other.Y && this.Z == other.Z && this.W == other.W;
-            //// ReSharper restore CompareOfFloatsByEqualityOperator
-        }
-
-        /// <summary>
-        /// Returns a value to indicate if a pair of Vector3DHomogeneous are equal
-        /// </summary>
-        /// <param name="other">The Vector3DHomogeneous to compare against.</param>
         /// <param name="tolerance">A tolerance (epsilon) to adjust for floating point error</param>
         /// <returns>True if the Vector3DHomogeneouses are equal; otherwise false</returns>
         public bool Equals(Vector3DHomogeneous other, double tolerance)
@@ -139,29 +150,21 @@
                    Math.Abs(other.W - this.W) < tolerance;
         }
 
-        /// <inheritdoc/>
-        public override bool Equals(object obj)
+        /// <summary>
+        /// Returns a value to indicate if a pair of Vector3DHomogeneous are equal
+        /// </summary>
+        /// <param name="other">The Vector3DHomogeneous to compare against.</param>
+        /// <returns>True if the Vector3DHomogeneouses are equal; otherwise false</returns>
+        public bool Equals(Vector3DHomogeneous other)
         {
-            if (obj is null)
-            {
-                return false;
-            }
-
-            return obj is Vector3DHomogeneous && this.Equals((Vector3DHomogeneous)obj);
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z) && this.W.Equals(other.W);
         }
 
         /// <inheritdoc/>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                var hashCode = this.X.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Y.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.Z.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.W.GetHashCode();
-                return hashCode;
-            }
-        }
+        public override bool Equals(object obj) => obj is Vector3DHomogeneous v && this.Equals(v);
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z, this.W);
 
         /// <summary>
         /// return new Point3DHomogeneous(this.X, this.Y, this.Z, this.W);

--- a/src/Spatial/Units/Angle.cs
+++ b/src/Spatial/Units/Angle.cs
@@ -374,13 +374,6 @@ namespace MathNet.Spatial.Units
             return this.Radians.CompareTo(value.Radians);
         }
 
-        /// <inheritdoc />
-        public bool Equals(Angle other)
-        {
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            return this.Radians == other.Radians;
-        }
-
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified <see cref="T:MathNet.Spatial.Units.Angle"/> object within the given tolerance.
         /// </summary>
@@ -408,21 +401,13 @@ namespace MathNet.Spatial.Units
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-
-            return obj is Angle angle && this.Equals(angle);
-        }
+        public bool Equals(Angle other) => this.Radians.Equals(other.Radians);
 
         /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return this.Radians.GetHashCode();
-        }
+        public override bool Equals(object obj) => obj is Angle a && this.Equals(a);
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(this.Radians);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema()

--- a/src/SpatialUnitTests/Euclidean/PolyLine2DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/PolyLine2DTests.cs
@@ -15,8 +15,7 @@
         {
             var testElement = new PolyLine2D(from x in points.Split(';') select Point2D.Parse(x));
             var checkElement = Point2D.Parse(expected);
-
-            Assert.AreEqual(checkElement, testElement[index]);
+            AssertGeometry.AreEqual(checkElement, testElement.Vertices.Skip(index).First());
         }
 
         [TestCase("0,0;0,1", 1.0)]

--- a/src/SpatialUnitTests/Euclidean/PolyLine3DTests.cs
+++ b/src/SpatialUnitTests/Euclidean/PolyLine3DTests.cs
@@ -15,8 +15,7 @@
         {
             var testElement = new PolyLine3D(from x in points.Split(';') select Point3D.Parse(x));
             var checkElement = Point3D.Parse(expected);
-
-            AssertGeometry.AreEqual(checkElement, testElement[index]);
+            AssertGeometry.AreEqual(checkElement, testElement.Vertices.Skip(index).First());
         }
 
         [TestCase("0,0,0;0,1,0", 1.0)]

--- a/src/SpatialUnitTests/Euclidean/QuaternionTests.cs
+++ b/src/SpatialUnitTests/Euclidean/QuaternionTests.cs
@@ -156,10 +156,12 @@
             return new Quaternion(real, x, y, z).Norm;
         }
 
+        [Test]
         [TestCaseSource(typeof(QuaternionCalculationTestClass), "DivisionTests")]
-        public Quaternion CanDivideQuaternionsUsingOperator(double a, double b, double c, double d, double w, double x, double y, double z)
+        public void CanDivideQuaternionsUsingOperator(Quaternion q1, Quaternion q2, Quaternion expected)
         {
-            return new Quaternion(a, b, c, d) / new Quaternion(w, x, y, z);
+            var result = q1 / q2;
+            Assert.IsTrue(result.Equals(expected, TestTolerance));
         }
 
         [Test]
@@ -286,21 +288,24 @@
             {
                 get
                 {
+                    var qexpected = new Quaternion(1, 0, 0, 0);
                     for (var i = 0; i < 10; ++i)
                     {
                         var a = new[] { random.NextDouble(), random.NextDouble(), random.NextDouble(), random.NextDouble() };
-                        yield return new TestCaseData(a[0], a[1], a[2], a[3], a[0], a[1], a[2], a[3]).Returns(new Quaternion(1, 0, 0, 0));
+                        var test1 = new Quaternion(a[0], a[1], a[2], a[3]);
+                        var test2 = new Quaternion(a[0], a[1], a[2], a[3]);
+                        yield return new TestCaseData(test1, test2, qexpected);
                     }
 
-                    yield return new TestCaseData(0, 0, 0, 0, 1, 1, 1, 1).Returns(new Quaternion(0, 0, 0, 0));
-                    yield return new TestCaseData(4, 4, 4, 4, 2, 2, 2, 2).Returns(new Quaternion(2, 0, 0, 0));
-                    yield return new TestCaseData(9, 9, 9, 9, 3, 3, 3, 3).Returns(new Quaternion(3, 0, 0, 0));
-                    yield return new TestCaseData(1, 0, 0, 0, 1, 2, 3, 4).Returns(new Quaternion(1d / 30, -1d / 15, -1d / 10, -2d / 15));
-                    yield return new TestCaseData(4, 6, 9, 18, 2, 3, 3, 9).Returns(new Quaternion(215d / 103, 27d / 103, 6d / 103, -9d / 103));
-                    yield return new TestCaseData(1, 2, 3, 4, 5, 6, 7, 8).Returns(new Quaternion(70d / 174, 0d, 16d / 174, 8d / 174));
-                    yield return new TestCaseData(1, 1, 1, 1, 0, 0, 0, 0).Returns(posInf);
-                    yield return new TestCaseData(0, 0, 0, 0, 0, 0, 0, 0).Returns(nanQuaternion);
-                    yield return new TestCaseData(-1, -1, -1, -1, 0, 0, 0, 0).Returns(posInf);
+                    yield return new TestCaseData(new Quaternion(0, 0, 0, 0), new Quaternion(1, 1, 1, 1), new Quaternion(0, 0, 0, 0));
+                    yield return new TestCaseData(new Quaternion(4, 4, 4, 4), new Quaternion(2, 2, 2, 2), new Quaternion(2, 0, 0, 0));
+                    yield return new TestCaseData(new Quaternion(9, 9, 9, 9), new Quaternion(3, 3, 3, 3), new Quaternion(3, 0, 0, 0));
+                    yield return new TestCaseData(new Quaternion(1, 0, 0, 0), new Quaternion(1, 2, 3, 4), new Quaternion(1d / 30, -1d / 15, -1d / 10, -2d / 15));
+                    yield return new TestCaseData(new Quaternion(4, 6, 9, 18), new Quaternion(2, 3, 3, 9), new Quaternion(215d / 103, 27d / 103, 6d / 103, -9d / 103));
+                    yield return new TestCaseData(new Quaternion(1, 2, 3, 4), new Quaternion(5, 6, 7, 8), new Quaternion(70d / 174, 0d, 16d / 174, 8d / 174));
+                    yield return new TestCaseData(new Quaternion(1, 1, 1, 1), new Quaternion(0, 0, 0, 0), posInf);
+                    yield return new TestCaseData(new Quaternion(0, 0, 0, 0), new Quaternion(0, 0, 0, 0), nanQuaternion);
+                    yield return new TestCaseData(new Quaternion(-1, -1, -1, -1), new Quaternion(0, 0, 0, 0), posInf);
                 }
             }
 

--- a/src/SpatialUnitTests/Euclidean/QuaternionTests.cs
+++ b/src/SpatialUnitTests/Euclidean/QuaternionTests.cs
@@ -15,6 +15,8 @@
     [TestFixture]
     public class QuaternionTests
     {
+        private const double TestTolerance = 0.000001;
+
         [Test]
         public void CanConstructQuaternion()
         {
@@ -137,13 +139,15 @@
             var quat = new Quaternion(real, x, y, z);
             var eulerAngles = quat.ToEulerAngles();
             var expected = new EulerAngles(Angle.FromRadians(expectedAsArray[0]), Angle.FromRadians(expectedAsArray[1]), Angle.FromRadians(expectedAsArray[2]));
-            Assert.AreEqual(expected, eulerAngles);
+            Assert.IsTrue(eulerAngles.Equals(expected, TestTolerance));
         }
 
+        [Test]
         [TestCaseSource(typeof(QuaternionCalculationTestClass), "LogTests")]
-        public Quaternion CanCalculateLog(Quaternion quat)
+        public void CanCalculateLog(Quaternion quat, Quaternion expected)
         {
-            return quat.Log();
+            var log = quat.Log();
+            Assert.IsTrue(log.Equals(expected, TestTolerance));
         }
 
         [TestCaseSource(typeof(QuaternionCalculationTestClass), "NormTests")]
@@ -181,9 +185,10 @@
 
         [Test]
         [TestCaseSource(typeof(QuaternionCalculationTestClass), "CanCalculatePower")]
-        public Quaternion CanCalculatePower(Quaternion q1, double k)
+        public void CanCalculatePower(Quaternion q1, double k, Quaternion expected)
         {
-            return q1.Pow(k);
+            var result = q1.Pow(k);
+            Assert.IsTrue(result.Equals(expected, TestTolerance));
         }
 
         [Test]
@@ -195,9 +200,10 @@
 
         [Test]
         [TestCaseSource(typeof(QuaternionCalculationTestClass), "CanCalculatePower")]
-        public Quaternion CanCalculatePowerUsingOperator(Quaternion q1, double k)
+        public void CanCalculatePowerUsingOperator(Quaternion q1, double k, Quaternion expected)
         {
-            return q1 ^ k;
+            var result = q1 ^ k;
+            Assert.IsTrue(result.Equals(expected, TestTolerance));
         }
 
         [Test]
@@ -342,17 +348,22 @@
                 get
                 {
                     var q0 = new Quaternion(0, 0, 0, 0);
-                    yield return new TestCaseData(q0, 3.981).Returns(q0);
+                    var q00 = new Quaternion(0, 0, 0, 0);
+                    yield return new TestCaseData(q0, 3.981, q00);
 
                     var q1 = new Quaternion(1, 0, 0, 0);
-                    yield return new TestCaseData(q1, 3.981).Returns(q1);
+                    var q11 = new Quaternion(1, 0, 0, 0);
+                    yield return new TestCaseData(q1, 3.981, q11);
 
                     var q2 = new Quaternion(1, 1, 1, 1).Normalized;
-                    yield return new TestCaseData(q2, 9.0).Returns(q2 * q2 * q2 * q2 * q2 * q2 * q2 * q2 * q2);
-                    yield return new TestCaseData(q2, 3.0).Returns(q2 * q2 * q2);
+                    var q29 = q2 * q2 * q2 * q2 * q2 * q2 * q2 * q2 * q2;
+                    var q23 = q2 * q2 * q2;
+                    yield return new TestCaseData(q2, 9.0, q29);
+                    yield return new TestCaseData(q2, 3.0, q23);
 
                     var q3 = new Quaternion(2, 2, 2, 2).Normalized;
-                    yield return new TestCaseData(q3, 9.0).Returns(q3 * q3 * q3 * q3 * q3 * q3 * q3 * q3 * q3);
+                    var q39 = q3 * q3 * q3 * q3 * q3 * q3 * q3 * q3 * q3;
+                    yield return new TestCaseData(q3, 9.0, q39);
                 }
             }
 
@@ -378,21 +389,28 @@
                 }
             }
 
-            public static IEnumerable LogTests
+            public static object[] LogTests
             {
                 get
                 {
                     var q0 = new Quaternion(1, 0, 0, 0);
+                    var q00 = new Quaternion(1, 0, 0, 0);
                     var q1 = new Quaternion(0, 0, 0, 1);
+                    var q10 = new Quaternion(0, 0, 0, Math.PI / 2);
                     var q2 = new Quaternion(1, 1, 1, 1);
-                    yield return new TestCaseData(q0).Returns(new Quaternion(1, 0, 0, 0));
-                    yield return new TestCaseData(q1).Returns(new Quaternion(0, 0, 0, Math.PI / 2));
-                    yield return new TestCaseData(q2).Returns(
-                        new Quaternion(
+                    var q20 = new Quaternion(
                             Math.Log(2),
                             1 / Math.Sqrt(3) * Math.PI / 3,
                             1 / Math.Sqrt(3) * Math.PI / 3,
-                            1 / Math.Sqrt(3) * Math.PI / 3));
+                            1 / Math.Sqrt(3) * Math.PI / 3);
+
+                    var tests = new object[]
+                    {
+                        new object[] { q0, q00 },
+                        new object[] { q1, q10 },
+                        new object[] {q2, q20 }
+                    };
+                    return tests;
                 }
             }
         }


### PR DESCRIPTION
All Euclidian types (+Angle) now consistently implement:
Equals
override Equals(object)
GetHashCode - using internal HashCode struct
Equals(T, double tolerance)
Operator overrides for == and !=

Additionally PolyLine2D and PolyLine3D are aligned to Polygon2D for vertex interface