### PR TITLE
Core Serialization Support

### DIFF
--- a/src/Spatial/Serialization/AngleSurrogate.cs
+++ b/src/Spatial/Serialization/AngleSurrogate.cs
@@ -1,0 +1,22 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Units;
+
+    /// <summary>
+    /// Surrogate for Angle
+    /// </summary>
+    [DataContract(Name = "Angle")]
+    [Serializable]
+    public class AngleSurrogate
+    {
+        [DataMember(Order = 1)]
+        public double Value;
+
+        public static implicit operator AngleSurrogate(Angle angle) => new AngleSurrogate { Value = angle.Radians };
+
+        public static implicit operator Angle(AngleSurrogate angle) => Angle.FromRadians(angle.Value);
+    }
+}

--- a/src/Spatial/Serialization/Binary/BinaryHelper.cs
+++ b/src/Spatial/Serialization/Binary/BinaryHelper.cs
@@ -1,0 +1,31 @@
+﻿namespace MathNet.Spatial.Serialization.Binary
+{
+#if NETSTANDARD1_3 == false
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Provides static methods for supporting binary serialization
+    /// </summary>
+    public static class BinaryHelper
+    {
+        /// <summary>
+        /// Creates a surrogate selector with all the spatial types and thier surrogates
+        /// </summary>
+        /// <returns>A surrogate selector</returns>
+        public static SurrogateSelector CreateSurrogateSelector()
+        {
+            SurrogateSelector s = new SurrogateSelector();
+            for (int i = 0; i < SpatialSerialization.SurrogateMap.Count; i++)
+            {
+                s.AddSurrogate(SpatialSerialization.SurrogateMap[i].Source, new StreamingContext(StreamingContextStates.All), new SpatialBinarySerializer());
+            }
+
+            return s;
+        }
+    }
+#endif
+}

--- a/src/Spatial/Serialization/Binary/SpatialBinarySerializer.cs
+++ b/src/Spatial/Serialization/Binary/SpatialBinarySerializer.cs
@@ -1,0 +1,81 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#if NETSTANDARD1_3 == false
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Serialization;
+
+    /// <summary>
+    /// This class provides serialization for spatial objects
+    /// </summary>
+    internal class SpatialBinarySerializer : ISerializationSurrogate
+    {
+        /// <inheritdoc />
+        public void GetObjectData(object obj, SerializationInfo info, StreamingContext context)
+        {
+            var surrogate = SpatialSerialization.GetObjectToSerialize(obj);
+            Type surrogateType = surrogate.GetType();
+            foreach (var field in surrogateType.GetFields())
+            {
+                if (field.FieldType.IsArray)
+                {
+                    // unfortunately the legacy formatters do not handled nested objects in arrays
+                    // so need to manually convert the type into a surrogate
+                    var list = field.GetValue(surrogate);
+                    int cnt = ((Array)list).Length;
+                    Type surrogateArrayElementType = SpatialSerialization.GetSurrogateType(field.FieldType.GetElementType());
+                    var surrogatedList = Array.CreateInstance(surrogateArrayElementType, cnt);
+                    int i = 0;
+                    foreach (object item in (Array)list)
+                    {
+                        var itemSurrogate = SpatialSerialization.GetObjectToSerialize(item);
+                        surrogatedList.SetValue(itemSurrogate, i++);
+                    }
+
+                    info.AddValue(field.Name, surrogatedList);
+                }
+                else
+                {
+                    info.AddValue(field.Name, field.GetValue(surrogate));
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public object SetObjectData(object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
+        {
+            Type surrogateType = SpatialSerialization.GetSurrogateType(obj.GetType());
+            var surrogate = Activator.CreateInstance(surrogateType);
+            foreach (var field in surrogateType.GetFields())
+            {
+                if (field.FieldType.IsArray)
+                {
+                    // unfortunately the legacy formatters do not handled nested objects in arrays
+                    // so need to manually convert back the type
+                    Type surrogateArrayElementType = SpatialSerialization.GetSurrogateType(field.FieldType.GetElementType());
+                    Type surrogateArrayType = surrogateArrayElementType.MakeArrayType();
+                    var surrogateArray = info.GetValue(field.Name, surrogateArrayType);
+                    int cnt = ((Array)surrogateArray).Length;
+                    int i = 0;
+                    var actualItemList = Array.CreateInstance(field.FieldType.GetElementType(), cnt);
+                    foreach (object item in (Array)surrogateArray)
+                    {
+                        var itemSurrogate = SpatialSerialization.GetDeserializedObject(item);
+                        actualItemList.SetValue(itemSurrogate, i++);
+                    }
+
+                    field.SetValue(surrogate, actualItemList);
+                }
+                else
+                {
+                    var value = info.GetValue(field.Name, field.FieldType);
+                    field.SetValue(surrogate, value);
+                }
+            }
+
+            var actual = SpatialSerialization.GetDeserializedObject(surrogate);
+            return actual;
+        }
+    }
+#endif
+}

--- a/src/Spatial/Serialization/Circle2DSurrogate.cs
+++ b/src/Spatial/Serialization/Circle2DSurrogate.cs
@@ -1,0 +1,21 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Circle2D")]
+    [Serializable]
+    public class Circle2DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point2D Center;
+        [DataMember(Order = 2)]
+        public double Radius;
+
+        public static implicit operator Circle2DSurrogate(Circle2D circle) => new Circle2DSurrogate { Center = circle.Center, Radius = circle.Radius };
+
+        public static implicit operator Circle2D(Circle2DSurrogate circle) => new Circle2D(circle.Center, circle.Radius);
+    }
+}

--- a/src/Spatial/Serialization/Circle3DSurrogate.cs
+++ b/src/Spatial/Serialization/Circle3DSurrogate.cs
@@ -1,0 +1,23 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Circle3D")]
+    [Serializable]
+    public class Circle3DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point3D CenterPoint;
+        [DataMember(Order = 2)]
+        public UnitVector3D Axis;
+        [DataMember(Order = 3)]
+        public double Radius;
+
+        public static implicit operator Circle3DSurrogate(Circle3D circle) => new Circle3DSurrogate { CenterPoint = circle.CenterPoint, Axis = circle.Axis, Radius = circle.Radius };
+
+        public static implicit operator Circle3D(Circle3DSurrogate circle) => new Circle3D(circle.CenterPoint, circle.Axis, circle.Radius);
+    }
+}

--- a/src/Spatial/Serialization/CoordinateSystemSurrogate.cs
+++ b/src/Spatial/Serialization/CoordinateSystemSurrogate.cs
@@ -1,0 +1,33 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "CoordinateSystem")]
+    [Serializable]
+    public class CoordinateSystemSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point3D Origin;
+        [DataMember(Order = 2)]
+        public Vector3D XAxis;
+        [DataMember(Order = 3)]
+        public Vector3D YAxis;
+        [DataMember(Order = 4)]
+        public Vector3D ZAxis;
+
+        public static implicit operator CoordinateSystemSurrogate(CoordinateSystem cs)
+        {
+            if (cs != null)
+            {
+                return new CoordinateSystemSurrogate { Origin = cs.Origin, XAxis = cs.XAxis, YAxis = cs.YAxis, ZAxis = cs.ZAxis };
+            }
+
+            return null;
+        }
+
+        public static implicit operator CoordinateSystem(CoordinateSystemSurrogate cs) => new CoordinateSystem(cs.Origin, cs.XAxis, cs.YAxis, cs.ZAxis);
+    }
+}

--- a/src/Spatial/Serialization/DataContracts/SpatialSerializationProvider.cs
+++ b/src/Spatial/Serialization/DataContracts/SpatialSerializationProvider.cs
@@ -1,0 +1,46 @@
+﻿namespace MathNet.Spatial.Serialization.DataContracts
+{
+    using System;
+#if NETSTANDARD2_0 == true
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Serialization;
+
+    /// <summary>
+    /// An implementation of ISerializationSurrogateProvider to support data contract serialization
+    /// </summary>
+    public class SpatialSerializationProvider : ISerializationSurrogateProvider
+    {
+        /// <summary>
+        /// Converts a surrogate object into a known Spatial object.  If type is unknown the original object is simply returned
+        /// </summary>
+        /// <param name="obj">The object to convert</param>
+        /// <param name="targetType">The Type of the serialization target</param>
+        /// <returns>A converted object if a convertor exists; otherwise the object passed</returns>
+        public object GetDeserializedObject(object obj, Type targetType)
+        {
+            return SpatialSerialization.GetDeserializedObject(obj);
+        }
+
+        /// <summary>
+        /// Converts a Spatial object into a surrogate for serialization
+        /// </summary>
+        /// <param name="obj">The object to convert</param>
+        /// <param name="targetType">The Type of the serialization target</param>
+        /// <returns>A converted object if a convertor exists; otherwise the object passed</returns>
+        public object GetObjectToSerialize(object obj, Type targetType)
+        {
+            return SpatialSerialization.GetObjectToSerialize(obj);
+        }
+
+        /// <summary>
+        /// returns the surrogate type for a given type.  If type is unknown it returns the type provided
+        /// </summary>
+        /// <param name="type">A spatial library type</param>
+        /// <returns>The type of a surrogate type</returns>
+        public Type GetSurrogateType(Type type)
+        {
+            return SpatialSerialization.GetSurrogateType(type);
+        }
+    }
+#endif
+}

--- a/src/Spatial/Serialization/EulerAnglesSurrogate.cs
+++ b/src/Spatial/Serialization/EulerAnglesSurrogate.cs
@@ -1,0 +1,24 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+    using MathNet.Spatial.Units;
+
+    [DataContract(Name = "EulerAngles")]
+    [Serializable]
+    public class EulerAnglesSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Angle Alpha;
+        [DataMember(Order = 2)]
+        public Angle Beta;
+        [DataMember(Order = 3)]
+        public Angle Gamma;
+
+        public static implicit operator EulerAnglesSurrogate(EulerAngles angles) => new EulerAnglesSurrogate { Alpha = angles.Alpha, Beta = angles.Beta, Gamma = angles.Gamma };
+
+        public static implicit operator EulerAngles(EulerAnglesSurrogate angles) => new EulerAngles(angles.Alpha, angles.Beta, angles.Gamma);
+    }
+}

--- a/src/Spatial/Serialization/LineSegment2DSurrogate.cs
+++ b/src/Spatial/Serialization/LineSegment2DSurrogate.cs
@@ -1,0 +1,21 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "LineSegment2D")]
+    [Serializable]
+    public class LineSegment2DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point2D StartPoint;
+        [DataMember(Order = 2)]
+        public Point2D EndPoint;
+
+        public static implicit operator LineSegment2DSurrogate(LineSegment2D line) => new LineSegment2DSurrogate { StartPoint = line.StartPoint, EndPoint = line.EndPoint };
+
+        public static implicit operator LineSegment2D(LineSegment2DSurrogate line) => new LineSegment2D(line.StartPoint, line.EndPoint);
+    }
+}

--- a/src/Spatial/Serialization/LineSegment3DSurrogate.cs
+++ b/src/Spatial/Serialization/LineSegment3DSurrogate.cs
@@ -1,0 +1,21 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "LineSegment3D")]
+    [Serializable]
+    public class LineSegment3DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point3D StartPoint;
+        [DataMember(Order = 2)]
+        public Point3D EndPoint;
+
+        public static implicit operator LineSegment3DSurrogate(LineSegment3D line) => new LineSegment3DSurrogate { StartPoint = line.StartPoint, EndPoint = line.EndPoint };
+
+        public static implicit operator LineSegment3D(LineSegment3DSurrogate line) => new LineSegment3D(line.StartPoint, line.EndPoint);
+    }
+}

--- a/src/Spatial/Serialization/PlaneSurrogate.cs
+++ b/src/Spatial/Serialization/PlaneSurrogate.cs
@@ -1,0 +1,21 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Plane")]
+    [Serializable]
+    public class PlaneSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point3D RootPoint;
+        [DataMember(Order = 2)]
+        public UnitVector3D Normal;
+
+        public static implicit operator PlaneSurrogate(Plane plane) => new PlaneSurrogate { RootPoint = plane.RootPoint, Normal = plane.Normal };
+
+        public static implicit operator Plane(PlaneSurrogate plane) => new Plane(plane.RootPoint, plane.Normal);
+    }
+}

--- a/src/Spatial/Serialization/Point2DSurrogate.cs
+++ b/src/Spatial/Serialization/Point2DSurrogate.cs
@@ -1,0 +1,21 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Point2D")]
+    [Serializable]
+    public class Point2DSurrogate
+    {
+        [DataMember(Order=1)]
+        public double X;
+        [DataMember(Order=2)]
+        public double Y;
+
+        public static implicit operator Point2DSurrogate(Point2D point) => new Point2DSurrogate { X = point.X, Y = point.Y };
+
+        public static implicit operator Point2D(Point2DSurrogate point) => new Point2D(point.X, point.Y);
+    }
+}

--- a/src/Spatial/Serialization/Point3DSurrogate.cs
+++ b/src/Spatial/Serialization/Point3DSurrogate.cs
@@ -1,0 +1,23 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Point3D")]
+    [Serializable]
+    public class Point3DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public double X;
+        [DataMember(Order = 2)]
+        public double Y;
+        [DataMember(Order = 3)]
+        public double Z;
+
+        public static implicit operator Point3DSurrogate(Point3D point) => new Point3DSurrogate { X = point.X, Y = point.Y, Z = point.Z };
+
+        public static implicit operator Point3D(Point3DSurrogate point) => new Point3D(point.X, point.Y, point.Z);
+    }
+}

--- a/src/Spatial/Serialization/PolyLine2DSurrogate.cs
+++ b/src/Spatial/Serialization/PolyLine2DSurrogate.cs
@@ -1,0 +1,20 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "PolyLine2D")]
+    [Serializable]
+    public class PolyLine2DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point2D[] Points;
+
+        public static implicit operator PolyLine2DSurrogate(PolyLine2D polyline) => new PolyLine2DSurrogate { Points = polyline.Vertices.ToArray() };
+
+        public static implicit operator PolyLine2D(PolyLine2DSurrogate polyline) => new PolyLine2D(polyline.Points);
+    }
+}

--- a/src/Spatial/Serialization/PolyLine3DSurrogate.cs
+++ b/src/Spatial/Serialization/PolyLine3DSurrogate.cs
@@ -1,0 +1,20 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "PolyLine3D")]
+    [Serializable]
+    public class PolyLine3DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point3D[] Points;
+
+        public static implicit operator PolyLine3DSurrogate(PolyLine3D polyline) => new PolyLine3DSurrogate { Points = polyline.Vertices.ToArray() };
+
+        public static implicit operator PolyLine3D(PolyLine3DSurrogate polyline) => new PolyLine3D(polyline.Points);
+    }
+}

--- a/src/Spatial/Serialization/Polygon2DSurrogate.cs
+++ b/src/Spatial/Serialization/Polygon2DSurrogate.cs
@@ -1,0 +1,20 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Polygon2D")]
+    [Serializable]
+    public class Polygon2DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point2D[] Points;
+
+        public static implicit operator Polygon2DSurrogate(Polygon2D polygon) => new Polygon2DSurrogate { Points = polygon.Vertices.ToArray() };
+
+        public static implicit operator Polygon2D(Polygon2DSurrogate polygon) => new Polygon2D(polygon.Points);
+    }
+}

--- a/src/Spatial/Serialization/QuaternionSurrogate.cs
+++ b/src/Spatial/Serialization/QuaternionSurrogate.cs
@@ -1,0 +1,25 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Quaternion")]
+    [Serializable]
+    public class QuaternionSurrogate
+    {
+        [DataMember(Order = 1)]
+        public double W;
+        [DataMember(Order = 2)]
+        public double X;
+        [DataMember(Order = 3)]
+        public double Y;
+        [DataMember(Order = 4)]
+        public double Z;
+
+        public static implicit operator QuaternionSurrogate(Quaternion quat) => new QuaternionSurrogate { W = quat.Real, X = quat.ImagX, Y = quat.ImagY, Z = quat.ImagZ };
+
+        public static implicit operator Quaternion(QuaternionSurrogate quat) => new Quaternion(quat.W, quat.X, quat.Y, quat.Z);
+    }
+}

--- a/src/Spatial/Serialization/Ray3DSurrogate.cs
+++ b/src/Spatial/Serialization/Ray3DSurrogate.cs
@@ -1,0 +1,21 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Ray3D")]
+    [Serializable]
+    public class Ray3DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public Point3D ThroughPoint;
+        [DataMember(Order = 2)]
+        public UnitVector3D Direction;
+
+        public static implicit operator Ray3DSurrogate(Ray3D ray) => new Ray3DSurrogate { ThroughPoint = ray.ThroughPoint, Direction = ray.Direction };
+
+        public static implicit operator Ray3D(Ray3DSurrogate ray) => new Ray3D(ray.ThroughPoint, ray.Direction);
+    }
+}

--- a/src/Spatial/Serialization/SpatialSerialization.cs
+++ b/src/Spatial/Serialization/SpatialSerialization.cs
@@ -1,0 +1,149 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#if NETSTANDARD1_3 == false
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+    using MathNet.Spatial.Units;
+
+    /// <summary>
+    /// Provides serialization helper methods for Spatial types.
+    /// </summary>
+    public static class SpatialSerialization
+    {
+        /// <summary>
+        /// Map of types
+        /// </summary>
+        internal static List<ContractConvertor> SurrogateMap = new List<ContractConvertor>()
+        {
+            new ContractConvertor(typeof(Point2D), typeof(Point2DSurrogate)),
+            new ContractConvertor(typeof(Point3D), typeof(Point3DSurrogate)),
+            new ContractConvertor(typeof(Vector2D), typeof(Vector2DSurrogate)),
+            new ContractConvertor(typeof(Vector3D), typeof(Vector3DSurrogate)),
+            new ContractConvertor(typeof(UnitVector3D), typeof(UnitVector3DSurrogate)),
+            new ContractConvertor(typeof(Angle), typeof(AngleSurrogate)),
+            new ContractConvertor(typeof(EulerAngles), typeof(EulerAnglesSurrogate)),
+            new ContractConvertor(typeof(LineSegment2D), typeof(LineSegment2DSurrogate)),
+            new ContractConvertor(typeof(LineSegment3D), typeof(LineSegment3DSurrogate)),
+            new ContractConvertor(typeof(Quaternion), typeof(QuaternionSurrogate)),
+            new ContractConvertor(typeof(Circle2D), typeof(Circle2DSurrogate)),
+            new ContractConvertor(typeof(Circle3D), typeof(Circle3DSurrogate)),
+            new ContractConvertor(typeof(Polygon2D), typeof(Polygon2DSurrogate)),
+            new ContractConvertor(typeof(PolyLine2D), typeof(PolyLine2DSurrogate)),
+            new ContractConvertor(typeof(PolyLine3D), typeof(PolyLine3DSurrogate)),
+            new ContractConvertor(typeof(Euclidean.CoordinateSystem), typeof(CoordinateSystemSurrogate)),
+            new ContractConvertor(typeof(Ray3D), typeof(Ray3DSurrogate)),
+            new ContractConvertor(typeof(Plane), typeof(PlaneSurrogate))
+        };
+
+        /// <summary>
+        /// Provides a list of known spatial surrogates in type pairs
+        /// </summary>
+        /// <returns>a list of type pairs</returns>
+        public static List<Tuple<Type, Type>> KnownSurrogates()
+        {
+            return SurrogateMap.Select(t => new Tuple<Type, Type>(t.Source, t.Surrogate)).ToList();
+        }
+
+        /// <summary>
+        /// Gets a value which indicates if a surrogate exists for a given type.
+        /// </summary>
+        /// <param name="type">A type</param>
+        /// <returns>True if there is a spatial surrogate for that type; otherwise false</returns>
+        public static bool CanConvert(Type type)
+        {
+            for (int i = 0; i < SpatialSerialization.SurrogateMap.Count; i++)
+            {
+                if (SurrogateMap[i].Source == type)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the serialization surrogate for a given spatial type
+        /// </summary>
+        /// <param name="type">a type</param>
+        /// <returns>A surrogate type</returns>
+        public static Type GetSurrogateType(Type type)
+        {
+            if (SpatialSerialization.SurrogateMap.Exists(t => t.Source == type))
+            {
+                return SpatialSerialization.SurrogateMap.Where(t => t.Source == type).First().Surrogate;
+            }
+            else
+            {
+                return type;
+            }
+        }
+
+        /// <summary>
+        /// Converts a given spatial type and data to the equivelent surrgate type if a conversion exists
+        /// </summary>
+        /// <param name="obj">The object to convert</param>
+        /// <returns>A surrogate object equivelent to the provided spatial object if a conversion exists; otherwise the object passed</returns>
+        public static object GetObjectToSerialize(object obj)
+        {
+            Type type = obj.GetType();
+            if (SpatialSerialization.SurrogateMap.Exists(t => t.Source == type))
+            {
+                var y = SpatialSerialization.SurrogateMap.Where(t => t.Source == type).First();
+                var conversionmethod = y.Surrogate.GetMethod("op_Implicit", new[] { y.Source });
+                return conversionmethod.Invoke(null, new[] { obj });
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Converts a surrogate type and data to an equivelent Spatial object
+        /// </summary>
+        /// <param name="obj">Surrogate data object</param>
+        /// <returns>A Spatial object coresponding to the provided surrgate object if a conversion exists; otherwise the object passed</returns>
+        public static object GetDeserializedObject(object obj)
+        {
+            Type surrogateType = obj.GetType();
+            if (SpatialSerialization.SurrogateMap.Exists(t => t.Surrogate == surrogateType))
+            {
+                var y = SpatialSerialization.SurrogateMap.Where(t => t.Surrogate == surrogateType).First();
+                var conversionmethod = y.Surrogate.GetMethod("op_Implicit", new[] { y.Surrogate });
+                return conversionmethod.Invoke(null, new[] { obj });
+            }
+
+            return obj;
+        }
+
+        /// <summary>
+        /// Internal class for storing the map from source type to surrogate
+        /// </summary>
+        internal class ContractConvertor
+        {
+            /// <summary>
+            /// A spatial library type
+            /// </summary>
+            public Type Source;
+
+            /// <summary>
+            /// A surrogate type
+            /// </summary>
+            public Type Surrogate;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ContractConvertor"/> class.
+            /// </summary>
+            /// <param name="source">A spatial library type</param>
+            /// <param name="surrogate">A surrogate type</param>
+            public ContractConvertor(Type source, Type surrogate)
+            {
+                this.Source = source;
+                this.Surrogate = surrogate;
+            }
+        }
+    }
+#endif
+}

--- a/src/Spatial/Serialization/UnitVector3DSurrogate.cs
+++ b/src/Spatial/Serialization/UnitVector3DSurrogate.cs
@@ -1,0 +1,23 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "UnitVector3D")]
+    [Serializable]
+    public class UnitVector3DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public double X;
+        [DataMember(Order = 2)]
+        public double Y;
+        [DataMember(Order = 3)]
+        public double Z;
+
+        public static implicit operator UnitVector3DSurrogate(UnitVector3D vector) => new UnitVector3DSurrogate { X = vector.X, Y = vector.Y, Z = vector.Z };
+
+        public static implicit operator UnitVector3D(UnitVector3DSurrogate vector) => UnitVector3D.Create(vector.X, vector.Y, vector.Z);
+    }
+}

--- a/src/Spatial/Serialization/Vector2DSurrogate.cs
+++ b/src/Spatial/Serialization/Vector2DSurrogate.cs
@@ -1,0 +1,21 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Vector2D")]
+    [Serializable]
+    public class Vector2DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public double X;
+        [DataMember(Order = 2)]
+        public double Y;
+
+        public static implicit operator Vector2DSurrogate(Vector2D vector) => new Vector2DSurrogate { X = vector.X, Y = vector.Y };
+
+        public static implicit operator Vector2D(Vector2DSurrogate vector) => new Vector2D(vector.X, vector.Y);
+    }
+}

--- a/src/Spatial/Serialization/Vector3DSurrogate.cs
+++ b/src/Spatial/Serialization/Vector3DSurrogate.cs
@@ -1,0 +1,23 @@
+﻿namespace MathNet.Spatial.Serialization
+{
+#pragma warning disable SA1600
+    using System;
+    using System.Runtime.Serialization;
+    using MathNet.Spatial.Euclidean;
+
+    [DataContract(Name = "Vector3D")]
+    [Serializable]
+    public class Vector3DSurrogate
+    {
+        [DataMember(Order = 1)]
+        public double X;
+        [DataMember(Order = 2)]
+        public double Y;
+        [DataMember(Order = 3)]
+        public double Z;
+
+        public static implicit operator Vector3DSurrogate(Vector3D vector) => new Vector3DSurrogate { X = vector.X, Y = vector.Y, Z = vector.Z };
+
+        public static implicit operator Vector3D(Vector3DSurrogate vector) => new Vector3D(vector.X, vector.Y, vector.Z);
+    }
+}

--- a/src/SpatialUnitTests/Serialization/BinaryFormatterTests.cs
+++ b/src/SpatialUnitTests/Serialization/BinaryFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿namespace MathNet.Spatial.UnitTests
+﻿namespace MathNet.Spatial.Serialization.UnitTests
 {
 #if NETCOREAPP1_1 == false
 
@@ -6,7 +6,9 @@
     using System.Linq;
     using System.Runtime.Serialization.Formatters.Binary;
     using MathNet.Spatial.Euclidean;
+    using MathNet.Spatial.Serialization.Binary;
     using MathNet.Spatial.Units;
+    using MathNet.Spatial.UnitTests;
     using NUnit.Framework;
 
     public class BinaryFormatterTests
@@ -37,7 +39,6 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void QuaternionBinaryFormatter()
         {
@@ -46,7 +47,6 @@
             Assert.AreEqual(q, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void EulerAnglesBinaryFormatter()
         {
@@ -64,8 +64,7 @@
             Assert.AreEqual(plane, result);
         }
 
-        [Explicit("fix later")]
-        [TestCase("1, 2, 3", "-1, 2, 3", false)]
+        [TestCase("1, 2, 3", "0, 0, 1", false)]
         public void Ray3DBinaryFormatter(string ps, string vs, bool asElements)
         {
             var ray = new Ray3D(Point3D.Parse(ps), UnitVector3D.Parse(vs));
@@ -74,17 +73,6 @@
             AssertGeometry.AreEqual(ray, result, 1e-6);
         }
 
-        [TestCase("1, 2, 3", "4, 5, 6")]
-        public void Line3DBinaryFormatter(string p1s, string p2s)
-        {
-            Point3D p1 = Point3D.Parse(p1s);
-            Point3D p2 = Point3D.Parse(p2s);
-            var l = new Line3D(p1, p2);
-            var result = this.BinaryFormmaterRoundTrip(l);
-            Assert.AreEqual(l, result);
-        }
-
-        [Explicit("fix later")]
         [TestCase("1, 2, 3", "4, 5, 6")]
         public void LineSegment3DBinaryFormatter(string p1s, string p2s)
         {
@@ -95,18 +83,6 @@
             Assert.AreEqual(l, result);
         }
 
-        [Explicit("fix later")]
-        [TestCase("1, 2", "4, 5")]
-        public void Line2DBinaryFormatter(string p1s, string p2s)
-        {
-            Point2D p1 = Point2D.Parse(p1s);
-            Point2D p2 = Point2D.Parse(p2s);
-            var l = new Line2D(p1, p2);
-            var result = this.BinaryFormmaterRoundTrip(l);
-            Assert.AreEqual(l, result);
-        }
-
-        [Explicit("fix later")]
         [TestCase("1, 2", "4, 5")]
         public void LineSegment2DBinaryFormatter(string p1s, string p2s)
         {
@@ -133,7 +109,6 @@
             Assert.AreEqual(v, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("0, 0", 3)]
         public void Circle2DBinaryFormatter(string point, double radius)
         {
@@ -152,7 +127,6 @@
             Assert.AreEqual(c, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void Polygon2DBinaryFormatter()
         {
@@ -162,7 +136,6 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void PolyLine2DBinaryFormatter()
         {
@@ -172,7 +145,6 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void PolyLine3DBinaryFormatter()
         {
@@ -182,13 +154,20 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void CoordinateSystemBinaryFormatter()
         {
-            var cs = new CoordinateSystem(new Point3D(1, -2, 3), new Vector3D(0, 1, 0), new Vector3D(0, 0, 1), new Vector3D(1, 0, 0));
+            var cs = new Spatial.Euclidean.CoordinateSystem(new Point3D(1, -2, 3), new Vector3D(0, 1, 0), new Vector3D(0, 0, 1), new Vector3D(1, 0, 0));
             var result = this.BinaryFormmaterRoundTrip(cs);
             AssertGeometry.AreEqual(cs, result);
+        }
+
+        [Test]
+        public void UnitVector3DBinaryFormatter()
+        {
+            var uv = UnitVector3D.Create(0.2672612419124244, -0.53452248382484879, 0.80178372573727319);
+            var result = this.BinaryFormmaterRoundTrip(uv);
+            AssertGeometry.AreEqual(uv, result);
         }
 
         private T BinaryFormmaterRoundTrip<T>(T test)
@@ -197,7 +176,7 @@
             {
                 var formatter = new BinaryFormatter();
 
-                // formatter.SurrogateSelector = SerializerFactory.CreateSurrogateSelector();
+                formatter.SurrogateSelector = BinaryHelper.CreateSurrogateSelector();
                 formatter.Serialize(ms, test);
                 ms.Flush();
                 ms.Position = 0;

--- a/src/SpatialUnitTests/Serialization/DataContractTests.cs
+++ b/src/SpatialUnitTests/Serialization/DataContractTests.cs
@@ -1,13 +1,14 @@
 ﻿namespace MathNet.Spatial.Serialization.Xml.UnitTests
 {
-#if NETCOREAPP1_1 == false
-
+#if NETCOREAPP2_0 == true
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization;
     using System.Xml;
+    using MathNet.Spatial;
     using MathNet.Spatial.Euclidean;
+    using MathNet.Spatial.Serialization.DataContracts;
     using MathNet.Spatial.Units;
     using MathNet.Spatial.UnitTests;
     using NUnit.Framework;
@@ -16,7 +17,6 @@
     {
         private const double Tolerance = 1e-6;
 
-        [Explicit("fix later")]
         [TestCase("15 °", @"<Angle><Value>0.26179938779914941</Value></Angle>")]
         public void AngleDataContract(string vs, string xml)
         {
@@ -25,7 +25,6 @@
             Assert.AreEqual(angle.Radians, result.Radians, Tolerance);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void Point2DDataContract()
         {
@@ -35,7 +34,6 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void Point3DDataContract()
         {
@@ -45,7 +43,6 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void QuaternionDataContract()
         {
@@ -55,7 +52,6 @@
             Assert.AreEqual(q, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void EulerAnglesDataContract()
         {
@@ -66,8 +62,7 @@
             Assert.AreEqual(eulerAngles, result);
         }
 
-        [Explicit("fix later")]
-        [TestCase("0, 0, 0", "0, 0, 1", @"<Plane><Normal><X>0</X><Y>0</Y><Z>1</Z></Normal><RootPoint><X>0</X><Y>0</Y><Z>0</Z></RootPoint></Plane>")]
+        [TestCase("0, 0, 0", "0, 0, 1", @"<Plane><RootPoint><X>0</X><Y>0</Y><Z>0</Z></RootPoint><Normal><X>0</X><Y>0</Y><Z>1</Z></Normal></Plane>")]
         public void PlaneDataContract(string rootPoint, string unitVector, string xml)
         {
             var plane = new Plane(Point3D.Parse(rootPoint), UnitVector3D.Parse(unitVector));
@@ -75,29 +70,16 @@
             Assert.AreEqual(plane, result);
         }
 
-        [Explicit("fix later")]
-        [TestCase("1, 2, 3", "-1, 2, 3", false, @"<Ray3D><Direction><X>-0.2672612419124244</X><Y>0.53452248382484879</Y><Z>0.80178372573727319</Z></Direction><ThroughPoint><X>1</X><Y>2</Y><Z>3</Z></ThroughPoint></Ray3D>")]
+        [TestCase("1, 2, 3", "-1, 2, 3", false, @"<Ray3D><ThroughPoint><X>1</X><Y>2</Y><Z>3</Z></ThroughPoint><Direction><X>-0.2672612419124244</X><Y>0.53452248382484879</Y><Z>0.80178372573727319</Z></Direction></Ray3D>")]
         public void Ray3DDataContract(string ps, string vs, bool asElements, string xml)
         {
-            var ray = new Ray3D(Point3D.Parse(ps), UnitVector3D.Parse(vs));
+            var ray = new Ray3D(Point3D.Parse(ps), Vector3D.Parse(vs).Normalize());
             var result = this.DataContractRoundTrip(ray, xml);
             Assert.AreEqual(ray, result);
             AssertGeometry.AreEqual(ray, result, 1e-6);
         }
 
-        [Explicit("fix later")]
-        [TestCase("1, 2, 3", "4, 5, 6", @"<Line3D><EndPoint><X>4</X><Y>5</Y><Z>6</Z></EndPoint><StartPoint><X>1</X><Y>2</Y><Z>3</Z></StartPoint></Line3D>")]
-        public void Line3DDataContract(string p1s, string p2s, string xml)
-        {
-            Point3D p1 = Point3D.Parse(p1s);
-            Point3D p2 = Point3D.Parse(p2s);
-            var l = new Line3D(p1, p2);
-            var result = this.DataContractRoundTrip(l, xml);
-            Assert.AreEqual(l, result);
-        }
-
-        [Explicit("fix later")]
-        [TestCase("1, 2, 3", "4, 5, 6", @"<LineSegment3D><EndPoint><X>4</X><Y>5</Y><Z>6</Z></EndPoint><StartPoint><X>1</X><Y>2</Y><Z>3</Z></StartPoint></LineSegment3D>")]
+        [TestCase("1, 2, 3", "4, 5, 6", @"<LineSegment3D><StartPoint><X>1</X><Y>2</Y><Z>3</Z></StartPoint><EndPoint><X>4</X><Y>5</Y><Z>6</Z></EndPoint></LineSegment3D>")]
         public void LineSegment3DDataContract(string p1s, string p2s, string xml)
         {
             Point3D p1 = Point3D.Parse(p1s);
@@ -107,19 +89,7 @@
             Assert.AreEqual(l, result);
         }
 
-        [Explicit("fix later")]
-        [TestCase("1, 2", "4, 5", @"<Line2D><EndPoint><X>4</X><Y>5</Y></EndPoint><StartPoint><X>1</X><Y>2</Y></StartPoint></Line2D>")]
-        public void Line2DDataContract(string p1s, string p2s, string xml)
-        {
-            Point2D p1 = Point2D.Parse(p1s);
-            Point2D p2 = Point2D.Parse(p2s);
-            var l = new Line2D(p1, p2);
-            var result = this.DataContractRoundTrip(l, xml);
-            Assert.AreEqual(l, result);
-        }
-
-        [Explicit("fix later")]
-        [TestCase("1, 2", "4, 5", @"<LineSegement2D><EndPoint><X>4</X><Y>5</Y></EndPoint><StartPoint><X>1</X><Y>2</Y></StartPoint></LineSegement2D>")]
+        [TestCase("1, 2", "4, 5", @"<LineSegment2D><StartPoint><X>1</X><Y>2</Y></StartPoint><EndPoint><X>4</X><Y>5</Y></EndPoint></LineSegment2D>")]
         public void LineSegment2DDataContract(string p1s, string p2s, string xml)
         {
             Point2D p1 = Point2D.Parse(p1s);
@@ -129,7 +99,6 @@
             Assert.AreEqual(l, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void Vector2DDataContract()
         {
@@ -139,7 +108,6 @@
             Assert.AreEqual(v, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void Vector3DDataContract()
         {
@@ -149,29 +117,26 @@
             Assert.AreEqual(v, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("0, 0", 3)]
         public void Circle2DDataContract(string point, double radius)
         {
             var center = Point2D.Parse(point);
             var c = new Circle2D(center, radius);
-            const string ElementXml = @"<Circle2D><CenterPoint><X>0</X><Y>0</Y></CenterPoint><Radius>3</Radius></Circle2D>";
+            const string ElementXml = @"<Circle2D><Center><X>0</X><Y>0</Y></Center><Radius>3</Radius></Circle2D>";
             var result = this.DataContractRoundTrip(c, ElementXml);
             Assert.AreEqual(c, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("0, 0, 0", 2.5)]
         public void Circle3DDataContract(string point, double radius)
         {
             var center = Point3D.Parse(point);
             var c = new Circle3D(center, UnitVector3D.ZAxis, radius);
-            const string ElementXml = @"<Circle3D><Axis><X>0</X><Y>0</Y><Z>1</Z></Axis><CenterPoint><X>0</X><Y>0</Y><Z>0</Z></CenterPoint><Radius>2.5</Radius></Circle3D>";
+            const string ElementXml = @"<Circle3D><CenterPoint><X>0</X><Y>0</Y><Z>0</Z></CenterPoint><Axis><X>0</X><Y>0</Y><Z>1</Z></Axis><Radius>2.5</Radius></Circle3D>";
             var result = this.DataContractRoundTrip(c, ElementXml);
             Assert.AreEqual(c, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void Polygon2DDataContract()
         {
@@ -182,7 +147,6 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void PolyLine2DDataContract()
         {
@@ -193,7 +157,6 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void PolyLine3DDataContract()
         {
@@ -204,34 +167,34 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void CoordinateSystemDataContract()
         {
-            var cs = new CoordinateSystem(new Point3D(1, -2, 3), new Vector3D(0, 1, 0), new Vector3D(0, 0, 1), new Vector3D(1, 0, 0));
+            var cs = new Euclidean.CoordinateSystem(new Point3D(1, -2, 3), new Vector3D(0, 1, 0), new Vector3D(0, 0, 1), new Vector3D(1, 0, 0));
             const string xml = @"
 <CoordinateSystem>
-    <Origin><X>1</X><Y>-2</Y><Z>3</Z><Origin>
+    <Origin><X>1</X><Y>-2</Y><Z>3</Z></Origin>
     <XAxis><X>0</X><Y>1</Y><Z>0</Z></XAxis>
     <YAxis><X>0</X><Y>0</Y><Z>1</Z></YAxis>
-    <ZAxis><X>1</X><Y>0</Y><Z>0</Z><ZAxis>
+    <ZAxis><X>1</X><Y>0</Y><Z>0</Z></ZAxis>
 </CoordinateSystem>";
             var result = this.DataContractRoundTrip(cs, xml);
             AssertGeometry.AreEqual(cs, result);
         }
 
         [Test]
-        public void DataContractRoundTripTest()
+        public void UnitVector3DDataContract()
         {
-            var dummy = new AssertXmlTests.XmlSerializableDummy("Meh", 14);
-            var roundTrip = this.DataContractRoundTrip(dummy, @"<AssertXmlTests.XmlSerializableDummy Age=""14""><Name>Meh</Name></AssertXmlTests.XmlSerializableDummy>");
-            Assert.AreEqual(dummy.Name, roundTrip.Name);
-            Assert.AreEqual(dummy.Age, roundTrip.Age);
+            var uv = UnitVector3D.Create(0.2672612419124244, -0.53452248382484879, 0.80178372573727319);
+            var elementXml = @"<UnitVector3D><X>0.2672612419124244</X><Y>-0.53452248382484879</Y><Z>0.80178372573727319</Z></UnitVector3D>";
+            var result = this.DataContractRoundTrip(uv, elementXml);
+            AssertGeometry.AreEqual(uv, result);
         }
 
         private T DataContractRoundTrip<T>(T item, string expected)
         {
             var serializer = new DataContractSerializer(item.GetType());
+            serializer.SetSerializationSurrogateProvider(new SpatialSerializationProvider());
             string xml;
             using (var sw = new StringWriter())
             using (var writer = XmlWriter.Create(sw, AssertXml.Settings))
@@ -252,6 +215,5 @@
             }
         }
     }
-
 #endif
 }

--- a/src/SpatialUnitTests/Serialization/ProtobufnetTests.cs
+++ b/src/SpatialUnitTests/Serialization/ProtobufnetTests.cs
@@ -1,5 +1,6 @@
-﻿namespace MathNet.Spatial.Serialization.Xml.UnitTests
+﻿namespace MathNet.Spatial.Serialization.UnitTests
 {
+#if NETCOREAPP1_1 == false
     using System.IO;
     using System.Linq;
     using MathNet.Spatial.Euclidean;
@@ -13,11 +14,15 @@
 
         public ProtobufNetTests()
         {
-            // ReSharper disable once UnusedVariable
             var model = ProtoBuf.Meta.RuntimeTypeModel.Default;
+            var surrogates = SpatialSerialization.KnownSurrogates();
+            surrogates.ForEach(t =>
+            {
+                model.Add(t.Item2, true);
+                model.Add(t.Item1, false).SetSurrogate(t.Item2);
+            });
         }
 
-        [Explicit("fix later")]
         [TestCase("15 °")]
         public void AngleProtoBuf(string vs)
         {
@@ -42,7 +47,6 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void QuaternionProtoBuf()
         {
@@ -51,7 +55,6 @@
             Assert.AreEqual(q, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void EulerAnglesProtoBuf()
         {
@@ -61,7 +64,6 @@
             Assert.AreEqual(eulerAngles, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("0, 0, 0", "0, 0, 1")]
         public void PlaneProtoBuf(string rootPoint, string unitVector)
         {
@@ -70,39 +72,15 @@
             Assert.AreEqual(plane, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("1, 2, 3", "-1, 2, 3", false)]
         public void Ray3DProtoBuf(string ps, string vs, bool asElements)
         {
-            var ray = new Ray3D(Point3D.Parse(ps), UnitVector3D.Parse(vs));
+            var ray = new Ray3D(Point3D.Parse(ps), Vector3D.Parse(vs).Normalize());
             var result = this.ProtobufRoundTrip(ray);
             Assert.AreEqual(ray, result);
             AssertGeometry.AreEqual(ray, result, 1e-6);
         }
 
-        [Explicit("fix later")]
-        [TestCase("1, 2, 3", "4, 5, 6")]
-        public void Line3DProtoBuf(string p1s, string p2s)
-        {
-            Point3D p1 = Point3D.Parse(p1s);
-            Point3D p2 = Point3D.Parse(p2s);
-            var l = new Line3D(p1, p2);
-            var result = this.ProtobufRoundTrip(l);
-            Assert.AreEqual(l, result);
-        }
-
-        [Explicit("fix later")]
-        [TestCase("1, 2", "4, 5")]
-        public void Line2DProtoBuf(string p1s, string p2s)
-        {
-            Point2D p1 = Point2D.Parse(p1s);
-            Point2D p2 = Point2D.Parse(p2s);
-            var l = new Line2D(p1, p2);
-            var result = this.ProtobufRoundTrip(l);
-            Assert.AreEqual(l, result);
-        }
-
-        [Explicit("fix later")]
         [TestCase("1, 2, 3", "4, 5, 6")]
         public void LineSegment3DProtoBuf(string p1s, string p2s)
         {
@@ -113,7 +91,6 @@
             Assert.AreEqual(l, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("1, 2", "4, 5")]
         public void LineSegment2DProtoBuf(string p1s, string p2s)
         {
@@ -124,7 +101,6 @@
             Assert.AreEqual(l, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void Vector2DProtoBuf()
         {
@@ -133,7 +109,6 @@
             Assert.AreEqual(v, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void Vector3DProtoBuf()
         {
@@ -142,7 +117,6 @@
             Assert.AreEqual(v, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("0, 0", 3)]
         public void Circle2DProtoBuf(string point, double radius)
         {
@@ -152,7 +126,6 @@
             Assert.AreEqual(c, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("0, 0, 0", 2.5)]
         public void Circle3DProtoBuf(string point, double radius)
         {
@@ -162,7 +135,7 @@
             Assert.AreEqual(c, result);
         }
 
-        [Explicit("fix later")]
+        [Explicit("Need to remove obsolete IEnumerable Interface")]
         [Test]
         public void Polygon2DProtoBuf()
         {
@@ -172,7 +145,7 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
+        [Explicit("Need to remove obsolete IEnumerable Interface")]
         [Test]
         public void PolyLine2DProtoBuf()
         {
@@ -182,7 +155,7 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
+        [Explicit("Need to remove obsolete IEnumerable Interface")]
         [Test]
         public void PolyLine3DProtoBuf()
         {
@@ -192,13 +165,20 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void CoordinateSystemProtoBuf()
         {
-            var cs = new CoordinateSystem(new Point3D(1, -2, 3), new Vector3D(0, 1, 0), new Vector3D(0, 0, 1), new Vector3D(1, 0, 0));
+            var cs = new Euclidean.CoordinateSystem(new Point3D(1, -2, 3), new Vector3D(0, 1, 0), new Vector3D(0, 0, 1), new Vector3D(1, 0, 0));
             var result = this.ProtobufRoundTrip(cs);
             AssertGeometry.AreEqual(cs, result);
+        }
+
+        [Test]
+        public void UnitVector3DProtoBuf()
+        {
+            var uv = UnitVector3D.Create(0.2672612419124244, -0.53452248382484879, 0.80178372573727319);
+            var result = this.ProtobufRoundTrip(uv);
+            AssertGeometry.AreEqual(uv, result);
         }
 
         private T ProtobufRoundTrip<T>(T test)
@@ -213,4 +193,5 @@
             }
         }
     }
+#endif
 }


### PR DESCRIPTION
This adds core serialization support for

DataContracts (netstandard2.0)
BinaryFormatter (net40 + netstandard20)
ProtoBuf (net40 + netstandard20)

No change to external dependencies required

