### PR TITLE
Convenience members for Angle

### DIFF
--- a/src/Spatial/Units/Angle.cs
+++ b/src/Spatial/Units/Angle.cs
@@ -29,6 +29,11 @@ namespace MathNet.Spatial.Units
         public static readonly Angle Degrees360 = Angle.FromRadians(2 * Math.PI);
 
         /// <summary>
+        /// An angle representing 0 degrees or 0 radians
+        /// </summary>
+        public static readonly Angle Degrees0 = Angle.FromRadians(0);
+
+        /// <summary>
         /// The value in radians
         /// </summary>
         public readonly double Radians;
@@ -363,14 +368,14 @@ namespace MathNet.Spatial.Units
         }
 
         /// <summary>
-        /// Normalizes an angle to be constrained within start and end.
+        /// Clamps an angle to be constrained within start and end.
         /// </summary>
         /// <param name="start">The start angle</param>
         /// <param name="end">The end angle</param>
-        /// <returns>The normalized angle</returns>
-        public Angle Normalize(Angle start, Angle end)
+        /// <returns>The clamped angle</returns>
+        public Angle Clamp(Angle start, Angle end)
         {
-            return this.Normalize(start.Radians, end.Radians);
+            return this.Clamp(start.Radians, end.Radians);
         }
 
         /// <inheritdoc />
@@ -533,12 +538,12 @@ namespace MathNet.Spatial.Units
         }
 
         /// <summary>
-        /// Normalizes an angle to be constrained within start and end.
+        /// Clamps an angle to be constrained within start and end.
         /// </summary>
         /// <param name="start">The start angle in radians</param>
         /// <param name="end">The end angle in radians</param>
-        /// <returns>The normalized angle</returns>
-        internal Angle Normalize(double start, double end)
+        /// <returns>The clamped angle</returns>
+        internal Angle Clamp(double start, double end)
         {
             double width = end - start;
             double offset = this.Radians - start;

--- a/src/Spatial/Units/Angle.cs
+++ b/src/Spatial/Units/Angle.cs
@@ -14,6 +14,21 @@ namespace MathNet.Spatial.Units
     public struct Angle : IComparable<Angle>, IEquatable<Angle>, IFormattable, IXmlSerializable
     {
         /// <summary>
+        /// An angle representing 180 degrees or PI radians
+        /// </summary>
+        public static readonly Angle Degrees180 = Angle.FromRadians(Math.PI);
+
+        /// <summary>
+        /// An angle representing 90 degrees or PI / 2 radians
+        /// </summary>
+        public static readonly Angle Degrees90 = Angle.FromRadians(Math.PI / 2);
+
+        /// <summary>
+        /// An angle representing 360 degrees or 2 * PI radians
+        /// </summary>
+        public static readonly Angle Degrees360 = Angle.FromRadians(2 * Math.PI);
+
+        /// <summary>
         /// The value in radians
         /// </summary>
         public readonly double Radians;
@@ -67,6 +82,15 @@ namespace MathNet.Spatial.Units
         /// Gets the value in degrees
         /// </summary>
         public double Degrees => this.Radians * RadToDeg;
+
+        /// <summary>
+        /// Explicit conversion from a numeric angle in radians to an Angle object
+        /// </summary>
+        /// <param name="radians">The angle in radians</param>
+        public static explicit operator Angle(double radians)
+        {
+            return Angle.FromRadians(radians);
+        }
 
         /// <summary>
         /// Returns a value that indicates whether two specified Angles are equal.
@@ -311,6 +335,44 @@ namespace MathNet.Spatial.Units
             return reader.ReadElementAs<Angle>();
         }
 
+        /// <summary>
+        /// Gets the sine of the angle
+        /// </summary>
+        /// <returns>The sine of the angle</returns>
+        public double Sin()
+        {
+            return Math.Sin(this.Radians);
+        }
+
+        /// <summary>
+        /// Gets the cosine of the angle
+        /// </summary>
+        /// <returns>The cosine of the angle</returns>
+        public double Cos()
+        {
+            return Math.Cos(this.Radians);
+        }
+
+        /// <summary>
+        /// Gets the tangent of the angle
+        /// </summary>
+        /// <returns>The tangent of the angle</returns>
+        public double Tan()
+        {
+            return Math.Tan(this.Radians);
+        }
+
+        /// <summary>
+        /// Normalizes an angle to be constrained within start and end.
+        /// </summary>
+        /// <param name="start">The start angle</param>
+        /// <param name="end">The end angle</param>
+        /// <returns>The normalized angle</returns>
+        public Angle Normalize(Angle start, Angle end)
+        {
+            return this.Normalize(start.Radians, end.Radians);
+        }
+
         /// <inheritdoc />
         public override string ToString()
         {
@@ -468,6 +530,20 @@ namespace MathNet.Spatial.Units
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
             writer.WriteAttribute("Value", this.Radians);
+        }
+
+        /// <summary>
+        /// Normalizes an angle to be constrained within start and end.
+        /// </summary>
+        /// <param name="start">The start angle in radians</param>
+        /// <param name="end">The end angle in radians</param>
+        /// <returns>The normalized angle</returns>
+        internal Angle Normalize(double start, double end)
+        {
+            double width = end - start;
+            double offset = this.Radians - start;
+
+            return Angle.FromRadians((offset - (Math.Floor(offset / width) * width)) + start);
         }
     }
 }

--- a/src/SpatialUnitTests/Units/AngleTests.cs
+++ b/src/SpatialUnitTests/Units/AngleTests.cs
@@ -128,6 +128,45 @@
             Assert.AreEqual(expected, Angle.FromSexagesimal(degrees, minutes, seconds).Radians, 1E-6);
         }
 
+        [TestCase(0, 0)]
+        [TestCase(Math.PI / 6, 0.5)]
+        [TestCase(Math.PI / 2, 1)]
+        [TestCase(4 * Math.PI / 3, -0.8660254037844386468)]
+        public void Sin(double radians, double expected)
+        {
+            Angle a = (Angle)radians;
+            Assert.AreEqual(expected, a.Sin(), Tolerance);
+        }
+
+        [TestCase(0, 1)]
+        [TestCase(Math.PI / 6, 0.8660254037844386468)]
+        [TestCase(Math.PI / 2, 0)]
+        [TestCase(4 * Math.PI / 3, -0.5)]
+        public void Cos(double radians, double expected)
+        {
+            Angle a = (Angle)radians;
+            Assert.AreEqual(expected, a.Cos(), Tolerance);
+        }
+
+        [TestCase(0, 0)]
+        [TestCase(Math.PI / 6, 0.57735026918962576451)]
+        [TestCase(Math.PI, 0)]
+        [TestCase(4 * Math.PI / 3, 1.73205080756887729353)]
+        public void Tan(double radians, double expected)
+        {
+            Angle a = (Angle)radians;
+            Assert.AreEqual(expected, a.Tan(), Tolerance);
+        }
+
+        [TestCase(Math.PI, 0, Math.PI * 2, Math.PI)]
+        [TestCase(3 * Math.PI, 0, Math.PI * 2, Math.PI)]
+        [TestCase(5 * Math.PI / 4, -Math.PI, Math.PI, -3 * Math.PI / 4)]
+        public void Normalize(double radians, double start, double end, double expected)
+        {
+            Angle a = Angle.FromRadians(radians);
+            Assert.AreEqual(expected, a.Normalize((Angle)start, (Angle)end).Radians, Tolerance);
+        }
+
         [TestCase("5 °", 5 * DegToRad)]
         [TestCase("5°", 5 * DegToRad)]
         [TestCase("-5.34 rad", -5.34)]

--- a/src/SpatialUnitTests/Units/AngleTests.cs
+++ b/src/SpatialUnitTests/Units/AngleTests.cs
@@ -161,10 +161,10 @@
         [TestCase(Math.PI, 0, Math.PI * 2, Math.PI)]
         [TestCase(3 * Math.PI, 0, Math.PI * 2, Math.PI)]
         [TestCase(5 * Math.PI / 4, -Math.PI, Math.PI, -3 * Math.PI / 4)]
-        public void Normalize(double radians, double start, double end, double expected)
+        public void Clamp(double radians, double start, double end, double expected)
         {
             Angle a = Angle.FromRadians(radians);
-            Assert.AreEqual(expected, a.Normalize((Angle)start, (Angle)end).Radians, Tolerance);
+            Assert.AreEqual(expected, a.Clamp((Angle)start, (Angle)end).Radians, Tolerance);
         }
 
         [TestCase("5 °", 5 * DegToRad)]


### PR DESCRIPTION
Adds the following:
Sin/Cos/Tan/Normalize methods to Angle
static angles for common angles 360, 180, 90

Explicit conversion from double to angle - allows (Angle)0.25 in the place of Angle.FromRadians(0.25).  This follows the logic that a double may be an angle but only if the programmer is sure it is.

