### PR TITLE
Serialization surrogate updates

### DIFF
--- a/src/Spatial/Serialization/AngleSurrogate.cs
+++ b/src/Spatial/Serialization/AngleSurrogate.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1600
     using System;
     using System.Runtime.Serialization;
+    using System.Xml.Serialization;
     using MathNet.Spatial.Units;
 
     /// <summary>
@@ -13,6 +14,7 @@
     public class AngleSurrogate
     {
         [DataMember(Order = 1)]
+        [XmlAttribute]
         public double Value;
 
         public static implicit operator AngleSurrogate(Angle angle) => new AngleSurrogate { Value = angle.Radians };

--- a/src/Spatial/Serialization/Point2DSurrogate.cs
+++ b/src/Spatial/Serialization/Point2DSurrogate.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1600
     using System;
     using System.Runtime.Serialization;
+    using System.Xml.Serialization;
     using MathNet.Spatial.Euclidean;
 
     [DataContract(Name = "Point2D")]
@@ -10,8 +11,10 @@
     public class Point2DSurrogate
     {
         [DataMember(Order=1)]
+        [XmlAttribute]
         public double X;
         [DataMember(Order=2)]
+        [XmlAttribute]
         public double Y;
 
         public static implicit operator Point2DSurrogate(Point2D point) => new Point2DSurrogate { X = point.X, Y = point.Y };

--- a/src/Spatial/Serialization/Point3DSurrogate.cs
+++ b/src/Spatial/Serialization/Point3DSurrogate.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1600
     using System;
     using System.Runtime.Serialization;
+    using System.Xml.Serialization;
     using MathNet.Spatial.Euclidean;
 
     [DataContract(Name = "Point3D")]
@@ -10,10 +11,13 @@
     public class Point3DSurrogate
     {
         [DataMember(Order = 1)]
+        [XmlAttribute]
         public double X;
         [DataMember(Order = 2)]
+        [XmlAttribute]
         public double Y;
         [DataMember(Order = 3)]
+        [XmlAttribute]
         public double Z;
 
         public static implicit operator Point3DSurrogate(Point3D point) => new Point3DSurrogate { X = point.X, Y = point.Y, Z = point.Z };

--- a/src/Spatial/Serialization/QuaternionSurrogate.cs
+++ b/src/Spatial/Serialization/QuaternionSurrogate.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1600
     using System;
     using System.Runtime.Serialization;
+    using System.Xml.Serialization;
     using MathNet.Spatial.Euclidean;
 
     [DataContract(Name = "Quaternion")]
@@ -10,12 +11,16 @@
     public class QuaternionSurrogate
     {
         [DataMember(Order = 1)]
+        [XmlAttribute]
         public double W;
         [DataMember(Order = 2)]
+        [XmlAttribute]
         public double X;
         [DataMember(Order = 3)]
+        [XmlAttribute]
         public double Y;
         [DataMember(Order = 4)]
+        [XmlAttribute]
         public double Z;
 
         public static implicit operator QuaternionSurrogate(Quaternion quat) => new QuaternionSurrogate { W = quat.Real, X = quat.ImagX, Y = quat.ImagY, Z = quat.ImagZ };

--- a/src/Spatial/Serialization/SpatialSerializationSurrogateProvider.cs
+++ b/src/Spatial/Serialization/SpatialSerializationSurrogateProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace MathNet.Spatial.Serialization.DataContracts
+﻿namespace MathNet.Spatial.Serialization
 {
     using System;
 #if NETSTANDARD2_0 == true
@@ -8,7 +8,7 @@
     /// <summary>
     /// An implementation of ISerializationSurrogateProvider to support data contract serialization
     /// </summary>
-    public class SpatialSerializationProvider : ISerializationSurrogateProvider
+    public class SpatialSerializationSurrogateProvider : ISerializationSurrogateProvider
     {
         /// <summary>
         /// Converts a surrogate object into a known Spatial object.  If type is unknown the original object is simply returned

--- a/src/Spatial/Serialization/UnitVector3DSurrogate.cs
+++ b/src/Spatial/Serialization/UnitVector3DSurrogate.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1600
     using System;
     using System.Runtime.Serialization;
+    using System.Xml.Serialization;
     using MathNet.Spatial.Euclidean;
 
     [DataContract(Name = "UnitVector3D")]
@@ -10,10 +11,13 @@
     public class UnitVector3DSurrogate
     {
         [DataMember(Order = 1)]
+        [XmlAttribute]
         public double X;
         [DataMember(Order = 2)]
+        [XmlAttribute]
         public double Y;
         [DataMember(Order = 3)]
+        [XmlAttribute]
         public double Z;
 
         public static implicit operator UnitVector3DSurrogate(UnitVector3D vector) => new UnitVector3DSurrogate { X = vector.X, Y = vector.Y, Z = vector.Z };

--- a/src/Spatial/Serialization/Vector2DSurrogate.cs
+++ b/src/Spatial/Serialization/Vector2DSurrogate.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1600
     using System;
     using System.Runtime.Serialization;
+    using System.Xml.Serialization;
     using MathNet.Spatial.Euclidean;
 
     [DataContract(Name = "Vector2D")]
@@ -10,8 +11,10 @@
     public class Vector2DSurrogate
     {
         [DataMember(Order = 1)]
+        [XmlAttribute]
         public double X;
         [DataMember(Order = 2)]
+        [XmlAttribute]
         public double Y;
 
         public static implicit operator Vector2DSurrogate(Vector2D vector) => new Vector2DSurrogate { X = vector.X, Y = vector.Y };

--- a/src/Spatial/Serialization/Vector3DSurrogate.cs
+++ b/src/Spatial/Serialization/Vector3DSurrogate.cs
@@ -3,6 +3,7 @@
 #pragma warning disable SA1600
     using System;
     using System.Runtime.Serialization;
+    using System.Xml.Serialization;
     using MathNet.Spatial.Euclidean;
 
     [DataContract(Name = "Vector3D")]
@@ -10,10 +11,13 @@
     public class Vector3DSurrogate
     {
         [DataMember(Order = 1)]
+        [XmlAttribute]
         public double X;
         [DataMember(Order = 2)]
+        [XmlAttribute]
         public double Y;
         [DataMember(Order = 3)]
+        [XmlAttribute]
         public double Z;
 
         public static implicit operator Vector3DSurrogate(Vector3D vector) => new Vector3DSurrogate { X = vector.X, Y = vector.Y, Z = vector.Z };

--- a/src/Spatial/Spatial.csproj
+++ b/src/Spatial/Spatial.csproj
@@ -83,6 +83,9 @@
     <PackageReference Include="System.Runtime.Serialization.Formatters">
       <Version>4.3.0</Version>
     </PackageReference>
+    <PackageReference Include="System.Xml.XmlSerializer">
+      <Version>4.3.0</Version>
+    </PackageReference>
     <Reference Include="MathNet.Numerics">
       <HintPath>..\..\packages\mathnet\MathNet.Numerics\lib\netstandard1.3\MathNet.Numerics.dll</HintPath>
       <Private>True</Private>

--- a/src/SpatialUnitTests/Serialization/DataContractTests.cs
+++ b/src/SpatialUnitTests/Serialization/DataContractTests.cs
@@ -8,7 +8,7 @@
     using System.Xml;
     using MathNet.Spatial;
     using MathNet.Spatial.Euclidean;
-    using MathNet.Spatial.Serialization.DataContracts;
+    using MathNet.Spatial.Serialization;
     using MathNet.Spatial.Units;
     using MathNet.Spatial.UnitTests;
     using NUnit.Framework;
@@ -194,7 +194,7 @@
         private T DataContractRoundTrip<T>(T item, string expected)
         {
             var serializer = new DataContractSerializer(item.GetType());
-            serializer.SetSerializationSurrogateProvider(new SpatialSerializationProvider());
+            serializer.SetSerializationSurrogateProvider(new SpatialSerializationSurrogateProvider());
             string xml;
             using (var sw = new StringWriter())
             using (var writer = XmlWriter.Create(sw, AssertXml.Settings))


### PR DESCRIPTION
Added XML attributes so xml formatting for the surrogates matches the existing xml format for those types with custom XML formatting

Fixed missing XML reference for .netstandard 1.3

Simplified the serialization namespace - no need for a datacontract specific item, its more general then that (although datacontracts is currently the only thing that uses it - this will change)