### PR TITLE
Additions for Xml Serialization

### DIFF
--- a/src/SpatialUnitTests/Helpers/AssertXml.cs
+++ b/src/SpatialUnitTests/Helpers/AssertXml.cs
@@ -41,7 +41,6 @@
             Assert.AreEqual(x1, x2);
         }
 
-
         /// <summary>
         /// Serializes using XmlSerializer & DataContractSerializer
         /// Compares the generated xml
@@ -65,23 +64,14 @@
 
         public static T XmlSerializerRoundTrip<T>(T item, string expected)
         {
-#if NETCOREAPP2_0 == true
-            var serializer = new ConfigurationContainer().Register(new SpatialSerializationSurrogateProvider())
-                                                         .Create();
-#else
             var serializer = new XmlSerializer(item.GetType());
-#endif
             string xml;
 
             using (var sw = new StringWriter())
             using (var writer = XmlWriter.Create(sw, Settings))
             {
-#if NETCOREAPP2_0 == true
-                xml = serializer.Serialize(item);
-#else
                 serializer.Serialize(writer, item);
                 xml = sw.ToString();
-#endif
                 Debug.WriteLine("XmlSerializer");
                 Debug.Write(xml);
                 Debug.WriteLine(string.Empty);
@@ -90,14 +80,34 @@
 
             using (var reader = new StringReader(xml))
             {
-#if NETCOREAPP2_0 == true
-                return serializer.Deserialize<T>(reader);
-#else
                 return (T)serializer.Deserialize(reader);
-#endif
             }
         }
 
+#if NETCOREAPP2_0 == true
+        public static T ExtendedXmlSerializerRoundTrip<T>(T item, string expected)
+        {
+
+            var serializer = new ConfigurationContainer().Register(new SpatialSerializationSurrogateProvider())
+                                                         .Create();
+            string xml;
+
+            using (var sw = new StringWriter())
+            using (var writer = XmlWriter.Create(sw, Settings))
+            {
+                xml = serializer.Serialize(item);
+                Debug.WriteLine("XmlSerializer");
+                Debug.Write(xml);
+                Debug.WriteLine(string.Empty);
+                AreEqual(expected, xml);
+            }
+
+            using (var reader = new StringReader(xml))
+            {
+                return serializer.Deserialize<T>(reader);
+            }
+        }
+#endif
 
         private static string Normalize(XElement e)
         {

--- a/src/SpatialUnitTests/Serialization/ExtendedXmlSerializaerTests.cs
+++ b/src/SpatialUnitTests/Serialization/ExtendedXmlSerializaerTests.cs
@@ -7,7 +7,7 @@
     using MathNet.Spatial.UnitTests;
     using NUnit.Framework;
 
-    public class XmlSerializaerTests
+    public class ExtendedXmlSerializaerTests
     {
         private const double Tolerance = 1e-6;
 
@@ -15,7 +15,7 @@
         public void Ray3DXml(string ps, string vs, bool asElements, string xml)
         {
             var ray = new Ray3D(Point3D.Parse(ps), UnitVector3D.Parse(vs));
-            var result = AssertXml.XmlSerializerRoundTrip(ray, xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(ray, xml);
             Assert.AreEqual(ray, result);
             AssertGeometry.AreEqual(ray, result, Tolerance);
         }
@@ -26,7 +26,7 @@
             Point3D p1 = Point3D.Parse(p1s);
             Point3D p2 = Point3D.Parse(p2s);
             var l = new LineSegment3D(p1, p2);
-            var result = AssertXml.XmlSerializerRoundTrip(l, xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(l, xml);
             Assert.AreEqual(l, result);
         }
 
@@ -36,7 +36,7 @@
             Point2D p1 = Point2D.Parse(p1s);
             Point2D p2 = Point2D.Parse(p2s);
             var l = new LineSegment2D(p1, p2);
-            var result = AssertXml.XmlSerializerRoundTrip(l, xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(l, xml);
             Assert.AreEqual(l, result);
         }
 
@@ -45,7 +45,7 @@
         {
             var v = new Vector2D(1, 2);
             const string Xml = @"<Vector2D X=""1"" Y=""2"" />";
-            var result = AssertXml.XmlSerializerRoundTrip(v, Xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(v, Xml);
             Assert.AreEqual(v, result);
         }
 
@@ -54,7 +54,7 @@
         {
             var v = new Vector3D(1, -2, 3);
             const string Xml = @"<Vector3D X=""1"" Y=""-2"" Z=""3"" />";
-            var result = AssertXml.XmlSerializerRoundTrip(v, Xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(v, Xml);
             Assert.AreEqual(v, result);
         }
 
@@ -63,7 +63,7 @@
         {
             var center = Point2D.Parse(point);
             var c = new Circle2D(center, radius);
-            var result = AssertXml.XmlSerializerRoundTrip(c, xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(c, xml);
             Assert.AreEqual(c, result);
         }
 
@@ -72,7 +72,7 @@
         {
             var center = Point3D.Parse(point);
             var c = new Circle3D(center, UnitVector3D.ZAxis, radius);
-            var result = AssertXml.XmlSerializerRoundTrip(c, xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(c, xml);
             Assert.AreEqual(c, result);
         }
 
@@ -82,7 +82,7 @@
             var points = from x in new string[] { "0.25,0", "0.5,1", "1,-1" } select Point2D.Parse(x);
             var p = new Polygon2D(points);
             const string Xml = @"<Polygon2D><Points><Point2D X=""0.25"" Y=""0"" /><Point2D X=""0.5"" Y=""1"" /><Point2D X=""1"" Y=""-1"" /></Points></Polygon2D>";
-            var result = AssertXml.XmlSerializerRoundTrip(p, Xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(p, Xml);
             Assert.AreEqual(p, result);
         }
 
@@ -92,7 +92,7 @@
             var points = from x in new string[] { "0.25,0", "0.5,1", "1,-1" } select Point2D.Parse(x);
             var p = new PolyLine2D(points);
             const string Xml = @"<PolyLine2D><Points><Point2D X=""0.25"" Y=""0"" /><Point2D X=""0.5"" Y=""1"" /><Point2D X=""1"" Y=""-1"" /></Points></PolyLine2D>";
-            var result = AssertXml.XmlSerializerRoundTrip(p, Xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(p, Xml);
             Assert.AreEqual(p, result);
         }
 
@@ -102,7 +102,7 @@
             var points = "0, -1.5, 0; 0,1,0; 1,1,0.5";
             var p = new PolyLine3D(from x in points.Split(';') select Point3D.Parse(x));
             const string Xml = @"<PolyLine3D><Points><Point3D X=""0"" Y=""-1.5"" Z=""0"" /><Point3D X=""0"" Y=""1"" Z=""0""  /><Point3D X=""1"" Y=""1"" Z=""0.5"" /></Points></PolyLine3D>";
-            var result = AssertXml.XmlSerializerRoundTrip(p, Xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(p, Xml);
             Assert.AreEqual(p, result);
         }
 
@@ -110,7 +110,7 @@
         public void PlaneXml(string rootPoint, string unitVector, string xml)
         {
             var plane = new Plane(Point3D.Parse(rootPoint), UnitVector3D.Parse(unitVector));
-            var result = AssertXml.XmlSerializerRoundTrip(plane, xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(plane, xml);
             Assert.AreEqual(plane, result);
         }
 
@@ -119,7 +119,7 @@
         {
             var p = new Point3D(1, -2, 3);
             const string Xml = @"<Point3D X=""1"" Y=""-2"" Z=""3"" />";
-            var result = AssertXml.XmlSerializerRoundTrip(p, Xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(p, Xml);
             Assert.AreEqual(p, result);
         }
 
@@ -128,7 +128,7 @@
         {
             var p = new Point2D(1, 2);
             const string Xml = @"<Point2D X=""1"" Y=""2"" />";
-            var result = AssertXml.XmlSerializerRoundTrip(p, Xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(p, Xml);
             Assert.AreEqual(p, result);
         }
 
@@ -137,7 +137,7 @@
         {
             var q = new Quaternion(1, 2, 3, 4);
             const string Xml = @"<Quaternion W=""1"" X=""2"" Y=""3"" Z=""4"" />";
-            var result = AssertXml.XmlSerializerRoundTrip(q, Xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(q, Xml);
             Assert.AreEqual(q, result);
         }
 
@@ -147,7 +147,7 @@
             var q = new Quaternion(0, 0, 0, 0);
             var eulerAngles = q.ToEulerAngles();
             const string Xml = @"<EulerAngles><Alpha Value=""0""></Alpha><Beta Value=""0""></Beta><Gamma Value=""0""></Gamma></EulerAngles>";
-            var result = AssertXml.XmlSerializerRoundTrip(eulerAngles, Xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(eulerAngles, Xml);
             Assert.AreEqual(eulerAngles, result);
         }
 
@@ -155,7 +155,7 @@
         public void AngleXml(string vs, string xml)
         {
             var angle = Angle.Parse(vs);
-            var result = AssertXml.XmlSerializerRoundTrip(angle, xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(angle, xml);
             Assert.AreEqual(angle.Radians, result.Radians, Tolerance);
         }
 
@@ -170,7 +170,7 @@
     <YAxis X=""0"" Y=""0"" Z=""1"" />
     <ZAxis X=""1"" Y=""0"" Z=""0"" />
 </CoordinateSystem>";
-            var result = AssertXml.XmlSerializerRoundTrip(cs, xml);
+            var result = AssertXml.ExtendedXmlSerializerRoundTrip(cs, xml);
             AssertGeometry.AreEqual(cs, result);
         }
     }

--- a/src/SpatialUnitTests/Serialization/XmlSerializaerTests.cs
+++ b/src/SpatialUnitTests/Serialization/XmlSerializaerTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MathNet.Spatial.Serialization.Xml.UnitTests
 {
+#if NETCOREAPP2_0 == true
     using System.Linq;
     using MathNet.Spatial.Euclidean;
     using MathNet.Spatial.Units;
@@ -10,8 +11,7 @@
     {
         private const double Tolerance = 1e-6;
 
-        [Explicit("fix later")]
-        [TestCase("1, 2, 3", "-1, 2, 3", false, @"<Ray3D><ThroughPoint X=""1"" Y=""2"" Z=""3"" /><Direction X=""-0.2672612419124244"" Y=""0.53452248382484879"" Z=""0.80178372573727319"" /></Ray3D>")]
+        [TestCase("1, 2, 3", "0, 0, 1", false, @"<Ray3D><ThroughPoint X=""1"" Y=""2"" Z=""3"" /><Direction X=""0"" Y=""0"" Z=""1"" /></Ray3D>")]
         public void Ray3DXml(string ps, string vs, bool asElements, string xml)
         {
             var ray = new Ray3D(Point3D.Parse(ps), UnitVector3D.Parse(vs));
@@ -20,29 +20,7 @@
             AssertGeometry.AreEqual(ray, result, Tolerance);
         }
 
-        [TestCase("1, 2, 3", "4, 5, 6", @"<Line3D><StartPoint X=""1"" Y=""2"" Z=""3"" /><EndPoint X=""4"" Y=""5"" Z=""6"" /></Line3D>")]
-        public void Line3DXml(string p1s, string p2s, string xml)
-        {
-            Point3D p1 = Point3D.Parse(p1s);
-            Point3D p2 = Point3D.Parse(p2s);
-            var l = new Line3D(p1, p2);
-            var result = AssertXml.XmlSerializerRoundTrip(l, xml);
-            Assert.AreEqual(l, result);
-        }
-
-        [Explicit("fix later")]
-        [TestCase("1, 2", "4, 5", @"<Line2D><StartPoint X=""1"" Y=""2"" /><EndPoint X=""4"" Y=""5"" /></Line2D>")]
-        public void Line2DXml(string p1s, string p2s, string xml)
-        {
-            Point2D p1 = Point2D.Parse(p1s);
-            Point2D p2 = Point2D.Parse(p2s);
-            var l = new Line2D(p1, p2);
-            var result = AssertXml.XmlSerializerRoundTrip(l, xml);
-            Assert.AreEqual(l, result);
-        }
-
-        [Explicit("fix later")]
-        [TestCase("1, 2, 3", "4, 5, 6", @"<LineSegement3D><StartPoint X=""1"" Y=""2"" Z=""3"" /><EndPoint X=""4"" Y=""5"" Z=""6"" /></LineSegment3D>")]
+        [TestCase("1, 2, 3", "4, 5, 6", @"<LineSegment3D><StartPoint X=""1"" Y=""2"" Z=""3"" /><EndPoint X=""4"" Y=""5"" Z=""6"" /></LineSegment3D>")]
         public void LineSegment3DXml(string p1s, string p2s, string xml)
         {
             Point3D p1 = Point3D.Parse(p1s);
@@ -52,7 +30,6 @@
             Assert.AreEqual(l, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("1, 2", "4, 5", @"<LineSegment2D><StartPoint X=""1"" Y=""2"" /><EndPoint X=""4"" Y=""5"" /></LineSegment2D>")]
         public void LineSegement2DXml(string p1s, string p2s, string xml)
         {
@@ -81,8 +58,7 @@
             Assert.AreEqual(v, result);
         }
 
-        [Explicit("fix later")]
-        [TestCase("1, 1", 3, @"<Circle2D><CenterPoint X=""1"" Y=""1"" /><Radius>3</Radius></Circle2D>")]
+        [TestCase("1, 1", 3, @"<Circle2D><Center X=""1"" Y=""1"" /><Radius>3</Radius></Circle2D>")]
         public void Circle2DXml(string point, double radius, string xml)
         {
             var center = Point2D.Parse(point);
@@ -91,7 +67,6 @@
             Assert.AreEqual(c, result);
         }
 
-        [Explicit("fix later")]
         [TestCase("0, 0, 0", 2.5, @"<Circle3D><CenterPoint X=""0"" Y=""0"" Z=""0"" /><Axis X=""0"" Y=""0"" Z=""1"" /><Radius>2.5</Radius></Circle3D>")]
         public void Circle3DXml(string point, double radius, string xml)
         {
@@ -101,35 +76,32 @@
             Assert.AreEqual(c, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void Polygon2DXml()
         {
             var points = from x in new string[] { "0.25,0", "0.5,1", "1,-1" } select Point2D.Parse(x);
             var p = new Polygon2D(points);
-            const string Xml = @"<Polygon2D><Points><Point X=""0.25"" Y=""0"" /><Point X=""0.5"" Y=""1"" /><Point X=""1"" Y=""-1"" /></Points></Polygon2D>";
+            const string Xml = @"<Polygon2D><Points><Point2D X=""0.25"" Y=""0"" /><Point2D X=""0.5"" Y=""1"" /><Point2D X=""1"" Y=""-1"" /></Points></Polygon2D>";
             var result = AssertXml.XmlSerializerRoundTrip(p, Xml);
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void PolyLine2DXml()
         {
             var points = from x in new string[] { "0.25,0", "0.5,1", "1,-1" } select Point2D.Parse(x);
             var p = new PolyLine2D(points);
-            const string Xml = @"<PolyLine2D><Points><Point X=""0.25"" Y=""0"" /><Point X=""0.5"" Y=""1"" /><Point X=""1"" Y=""-1"" /></Points></PolyLine2D>";
+            const string Xml = @"<PolyLine2D><Points><Point2D X=""0.25"" Y=""0"" /><Point2D X=""0.5"" Y=""1"" /><Point2D X=""1"" Y=""-1"" /></Points></PolyLine2D>";
             var result = AssertXml.XmlSerializerRoundTrip(p, Xml);
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void PolyLine3DXml()
         {
-            var points = "0, -1.5, 0; 0,1,0; 1,1,0";
+            var points = "0, -1.5, 0; 0,1,0; 1,1,0.5";
             var p = new PolyLine3D(from x in points.Split(';') select Point3D.Parse(x));
-            const string Xml = @"<PolyLine3D><Points><Point X=""0.25"" Y=""0"" /><Point X=""0.5"" Y=""1"" /><Point X=""1"" Y=""-1"" /></Points></PolyLine3D>";
+            const string Xml = @"<PolyLine3D><Points><Point3D X=""0"" Y=""-1.5"" Z=""0"" /><Point3D X=""0"" Y=""1"" Z=""0""  /><Point3D X=""1"" Y=""1"" Z=""0.5"" /></Points></PolyLine3D>";
             var result = AssertXml.XmlSerializerRoundTrip(p, Xml);
             Assert.AreEqual(p, result);
         }
@@ -160,7 +132,6 @@
             Assert.AreEqual(p, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void QuaternionXml()
         {
@@ -170,7 +141,6 @@
             Assert.AreEqual(q, result);
         }
 
-        [Explicit("fix later")]
         [Test]
         public void EulerAnglesXml()
         {
@@ -204,4 +174,5 @@
             AssertGeometry.AreEqual(cs, result);
         }
     }
+#endif
 }

--- a/src/SpatialUnitTests/SpatialUnitTests.csproj
+++ b/src/SpatialUnitTests/SpatialUnitTests.csproj
@@ -18,6 +18,9 @@
     <DefineConstants>NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
+    <PackageReference Include="ExtendedXmlSerializer">
+      <Version>2.1.1</Version>
+    </PackageReference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
@@ -30,6 +33,9 @@
     <ProjectReference Include="..\Spatial.Serialization.Json\Spatial.Serialization.Json.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="ExtendedXmlSerializer">
+      <Version>2.1.1</Version>
+    </PackageReference>
     <ProjectReference Include="..\Spatial.Serialization.Json\Spatial.Serialization.Json.csproj" />
   </ItemGroup>
   <ItemGroup>
@@ -39,7 +45,7 @@
     <PackageReference Include="NUnit" Version="3.9" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="NUnitLite" Version="3.9" />
-    <PackageReference Include="protobuf-net" Version="2.3.3" />
+    <PackageReference Include="protobuf-net" Version="2.3.6" />
     <ProjectReference Include="..\Spatial\Spatial.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION

Test support for Xml Serialization via ExtendedXmlSerializer
Update Protobuf-net version

This provides the last supporting piece needed to be able to remove serialization attributes and special serialization tags on the main types.  The actual removal should be raised as a separate item once this is released.

Note: Currently full serialization xml, json, protobuf, binary, datacontracts is only available under the .netstandard2.0 version.  If the minimum framework version is updated to 4.5 most of it can be back ported for that.
