### PR TITLE
Update XmlExt.cs

### DIFF
--- a/src/Spatial/Obsolete/XmlExt.cs
+++ b/src/Spatial/Obsolete/XmlExt.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/src/Spatial/Obsolete/XmlExt.cs
+++ b/src/Spatial/Obsolete/XmlExt.cs
@@ -187,7 +187,7 @@ namespace MathNet.Spatial
         public static XmlWriter WriteAttribute(this XmlWriter writer, string name, double value)
         {
             writer.WriteStartAttribute(name);
-            writer.WriteValue(value.ToString("G15"));
+            writer.WriteValue(value.ToString("G15", CultureInfo.InvariantCulture));
             writer.WriteEndAttribute();
             return writer;
         }


### PR DESCRIPTION
line 190: writer.WriteValue(value.ToString("G15")); ToString() without culture format provider parameter uses local culture. This causing issues when deserializing on machines with comma decimal separator.