### PR TITLE
Update Vector3DHomogeneous.cs

### DIFF
--- a/src/Spatial/Projective/Point3DHomogeneous.cs
+++ b/src/Spatial/Projective/Point3DHomogeneous.cs
@@ -12,22 +12,22 @@ namespace MathNet.Spatial.Projective
     internal struct Point3DHomogeneous : IEquatable<Point3DHomogeneous>
     {
         /// <summary>
-        /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
+        /// Using public fields for performance.
         /// </summary>
         public readonly double X;
 
         /// <summary>
-        /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
+        /// Using public fields for performance.
         /// </summary>
         public readonly double Y;
 
         /// <summary>
-        /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
+        /// Using public fields for performance.
         /// </summary>
         public readonly double Z;
 
         /// <summary>
-        /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
+        /// Using public fields for performance.
         /// </summary>
         public readonly double W;
 
@@ -40,10 +40,10 @@ namespace MathNet.Spatial.Projective
         /// <param name="w">The w value</param>
         public Point3DHomogeneous(double x, double y, double z, double w)
         {
-            this.X = x;
-            this.Y = y;
-            this.Z = z;
-            this.W = w;
+            X = x;
+            Y = y;
+            Z = z;
+            W = w;
         }
 
         /// <summary>
@@ -51,12 +51,15 @@ namespace MathNet.Spatial.Projective
         /// </summary>
         /// <param name="vector">A mathnet.numerics vector</param>
         private Point3DHomogeneous(Vector<double> vector)
-            : this(vector.At(0), vector.At(1), vector.At(2), vector.At(3))
         {
             if (vector.Count != 4)
             {
                 throw new ArgumentException("Size must be 4");
             }
+            X = vector[0];
+            Y = vector[1];
+            Z = vector[2];
+            W = vector[3];
         }
 
         /// <summary>
@@ -99,7 +102,7 @@ namespace MathNet.Spatial.Projective
         /// <inheritdoc />
         public override string ToString()
         {
-            return this.ToString("G15", CultureInfo.InvariantCulture);
+            return ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -109,7 +112,7 @@ namespace MathNet.Spatial.Projective
         /// <returns>The string representation of this instance.</returns>
         public string ToString(IFormatProvider provider)
         {
-            return this.ToString("G15", provider);
+            return ToString("G15", provider);
         }
 
         /// <summary>
@@ -122,7 +125,7 @@ namespace MathNet.Spatial.Projective
         {
             var numberFormatInfo = provider != null ? NumberFormatInfo.GetInstance(provider) : CultureInfo.InvariantCulture.NumberFormat;
             var separator = numberFormatInfo.NumberDecimalSeparator == "," ? ";" : ",";
-            return string.Format("({0}{1} {2}{1} {3}{1} {4})", this.X.ToString(format, numberFormatInfo), separator, this.Y.ToString(format, numberFormatInfo), this.Z.ToString(format, numberFormatInfo), this.W.ToString(format, numberFormatInfo));
+            return string.Format("({0}{1} {2}{1} {3}{1} {4})", X.ToString(format, numberFormatInfo), separator, Y.ToString(format, numberFormatInfo), Z.ToString(format, numberFormatInfo), W.ToString(format, numberFormatInfo));
         }
 
         /// <summary>
@@ -138,23 +141,23 @@ namespace MathNet.Spatial.Projective
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - this.X) < tolerance &&
-                   Math.Abs(other.Y - this.Y) < tolerance &&
-                   Math.Abs(other.Z - this.Z) < tolerance &&
-                   Math.Abs(other.W - this.W) < tolerance;
+            return Math.Abs(other.X - X) < tolerance &&
+                   Math.Abs(other.Y - Y) < tolerance &&
+                   Math.Abs(other.Z - Z) < tolerance &&
+                   Math.Abs(other.W - W) < tolerance;
         }
 
         /// <inheritdoc/>
         public bool Equals(Point3DHomogeneous other)
         {
-            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z) && this.W.Equals(other.W);
+            return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z) && W.Equals(other.W);
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Point3DHomogeneous p && this.Equals(p);
+        public override bool Equals(object obj) => obj is Point3DHomogeneous p && Equals(p);
 
         /// <inheritdoc/>
-        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z, this.W);
+        public override int GetHashCode() => HashCode.Combine(X, Y, Z, W);
 
         /// <summary>
         /// Gets a vector3D
@@ -163,9 +166,9 @@ namespace MathNet.Spatial.Projective
         public Vector3D ToVector3D()
         {
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (this.W != 0)
+            if (W != 0)
             {
-                return new Vector3D(this.X / this.W, this.X / this.W, this.X / this.W);
+                return new Vector3D(X / W, Y / W, Z / W);
             }
 
             return Vector3D.NaN;
@@ -177,16 +180,16 @@ namespace MathNet.Spatial.Projective
         /// <returns> A <see cref="Vector{Double}"/> with the x, y, z and w values from this instance.</returns>
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { this.X, this.Y, this.Z, this.W });
+            return Vector<double>.Build.Dense(new[] { X, Y, Z, W });
         }
 
         /// <summary>
-        /// return new Vector3DHomogeneous(this.X, this.Y, this.Z, this.W);
+        /// return new Vector3DHomogeneous(X, Y, Z, W);
         /// </summary>
         /// <returns> A <see cref="Vector3DHomogeneous"/> with the same x, y, z and w as this instance.</returns>
         public Vector3DHomogeneous ToVector3DHomogeneous()
         {
-            return new Vector3DHomogeneous(this.X, this.Y, this.Z, this.W);
+            return new Vector3DHomogeneous(X, Y, Z, W);
         }
 
         /// <summary>
@@ -196,7 +199,7 @@ namespace MathNet.Spatial.Projective
         /// <returns>A transformed Point3DHomogeneous</returns>
         public Point3DHomogeneous TransformBy(Matrix<double> m)
         {
-            return new Point3DHomogeneous(m.Multiply(Vector<double>.Build.Dense(new[] { this.X, this.Y, this.Z, this.W })));
+            return new Point3DHomogeneous(m.Multiply(Vector<double>.Build.Dense(new[] { X, Y, Z, W })));
         }
     }
 }

--- a/src/Spatial/Projective/Vector3DHomogeneous.cs
+++ b/src/Spatial/Projective/Vector3DHomogeneous.cs
@@ -12,22 +12,22 @@ namespace MathNet.Spatial.Projective
     internal struct Vector3DHomogeneous : IEquatable<Vector3DHomogeneous>
     {
         /// <summary>
-        /// Using public fields for performance. 
+        /// Using public fields for performance.
         /// </summary>
         public readonly double X;
 
         /// <summary>
-        /// Using public fields for performance. 
+        /// Using public fields for performance.
         /// </summary>
         public readonly double Y;
 
         /// <summary>
-        /// Using public fields for performance. 
+        /// Using public fields for performance.
         /// </summary>
         public readonly double Z;
 
         /// <summary>
-        /// Using public fields for performance. 
+        /// Using public fields for performance.
         /// </summary>
         public readonly double W;
 

--- a/src/Spatial/Projective/Vector3DHomogeneous.cs
+++ b/src/Spatial/Projective/Vector3DHomogeneous.cs
@@ -40,10 +40,10 @@ namespace MathNet.Spatial.Projective
         /// <param name="w">The w value</param>
         public Vector3DHomogeneous(double x, double y, double z, double w)
         {
-            this.X = x;
-            this.Y = y;
-            this.Z = z;
-            this.W = w;
+            X = x;
+            Y = y;
+            Z = z;
+            W = w;
         }
 
         /// <summary>
@@ -56,10 +56,10 @@ namespace MathNet.Spatial.Projective
             {
                 throw new ArgumentException("Size must be 4");
             }
-            this.X = vector.At(0);
-            this.Y = vector.At(1);
-            this.Z = vector.At(2);
-            this.W = vector.At(3);
+            X = vector[0];
+            Y = vector[1];
+            Z = vector[2];
+            W = vector[3];
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace MathNet.Spatial.Projective
         /// <inheritdoc/>
         public override string ToString()
         {
-            return this.ToString("G15", CultureInfo.InvariantCulture);
+            return ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace MathNet.Spatial.Projective
         /// <returns>The string representation of this instance.</returns>
         public string ToString(IFormatProvider provider)
         {
-            return this.ToString("G15", provider);
+            return ToString("G15", provider);
         }
 
         /// <summary>
@@ -128,10 +128,10 @@ namespace MathNet.Spatial.Projective
             return string.Format(
                 "({1}{0} {2}{0} {3}{0} {4})",
                 separator,
-                this.X.ToString(format, numberFormatInfo),
-                this.Y.ToString(format, numberFormatInfo),
-                this.Z.ToString(format, numberFormatInfo),
-                this.W.ToString(format, numberFormatInfo));
+                X.ToString(format, numberFormatInfo),
+                Y.ToString(format, numberFormatInfo),
+                Z.ToString(format, numberFormatInfo),
+                W.ToString(format, numberFormatInfo));
         }
 
         /// <summary>
@@ -147,10 +147,10 @@ namespace MathNet.Spatial.Projective
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - this.X) < tolerance &&
-                   Math.Abs(other.Y - this.Y) < tolerance &&
-                   Math.Abs(other.Z - this.Z) < tolerance &&
-                   Math.Abs(other.W - this.W) < tolerance;
+            return Math.Abs(other.X - X) < tolerance &&
+                   Math.Abs(other.Y - Y) < tolerance &&
+                   Math.Abs(other.Z - Z) < tolerance &&
+                   Math.Abs(other.W - W) < tolerance;
         }
 
         /// <summary>
@@ -160,22 +160,22 @@ namespace MathNet.Spatial.Projective
         /// <returns>True if the Vector3DHomogeneouses are equal; otherwise false</returns>
         public bool Equals(Vector3DHomogeneous other)
         {
-            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z) && this.W.Equals(other.W);
+            return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z) && W.Equals(other.W);
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj) => obj is Vector3DHomogeneous v && this.Equals(v);
+        public override bool Equals(object obj) => obj is Vector3DHomogeneous v && Equals(v);
 
         /// <inheritdoc/>
-        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z, this.W);
+        public override int GetHashCode() => HashCode.Combine(X, Y, Z, W);
 
         /// <summary>
-        /// return new Point3DHomogeneous(this.X, this.Y, this.Z, this.W);
+        /// return new Point3DHomogeneous(X, Y, Z, W);
         /// </summary>
         /// <returns> A <see cref="Point3DHomogeneous"/> with the same x, y, z and w as this instance.</returns>
         public Point3DHomogeneous ToPoint3DHomogeneous()
         {
-            return new Point3DHomogeneous(this.X, this.Y, this.Z, this.W);
+            return new Point3DHomogeneous(X, Y, Z, W);
         }
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace MathNet.Spatial.Projective
         /// <returns>A transformed Vector3DHomogeneous</returns>
         public Vector3DHomogeneous TransformBy(Matrix<double> m)
         {
-            return new Vector3DHomogeneous(m.Multiply(this.ToVector()));
+            return new Vector3DHomogeneous(m.Multiply(ToVector()));
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace MathNet.Spatial.Projective
         /// <returns> A <see cref="Vector{Double}"/> with the x, y, z and w values from this instance.</returns>
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { this.X, this.Y, this.Z, this.W });
+            return Vector<double>.Build.Dense(new[] { X, Y, Z, W });
         }
 
         /// <summary>
@@ -204,9 +204,9 @@ namespace MathNet.Spatial.Projective
         public Vector3D ToVector3D()
         {
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (this.W != 0)
+            if (W != 0)
             {
-                return new Vector3D(this.X / this.W, this.Y / this.W, this.Z / this.W);
+                return new Vector3D(X / W, Y / W, Z / W);
             }
 
             return Vector3D.NaN;

--- a/src/Spatial/Projective/Vector3DHomogeneous.cs
+++ b/src/Spatial/Projective/Vector3DHomogeneous.cs
@@ -12,22 +12,22 @@ namespace MathNet.Spatial.Projective
     internal struct Vector3DHomogeneous : IEquatable<Vector3DHomogeneous>
     {
         /// <summary>
-        /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
+        /// Using public fields for performance. 
         /// </summary>
         public readonly double X;
 
         /// <summary>
-        /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
+        /// Using public fields for performance. 
         /// </summary>
         public readonly double Y;
 
         /// <summary>
-        /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
+        /// Using public fields for performance. 
         /// </summary>
         public readonly double Z;
 
         /// <summary>
-        /// Using public fields cos: http://blogs.msdn.com/b/ricom/archive/2006/08/31/performance-quiz-11-ten-questions-on-value-based-programming.aspx
+        /// Using public fields for performance. 
         /// </summary>
         public readonly double W;
 
@@ -51,12 +51,15 @@ namespace MathNet.Spatial.Projective
         /// </summary>
         /// <param name="vector">A mathnet.numerics vector</param>
         private Vector3DHomogeneous(Vector<double> vector)
-            : this(vector.At(0), vector.At(1), vector.At(2), vector.At(2))
         {
             if (vector.Count != 4)
             {
                 throw new ArgumentException("Size must be 4");
             }
+            this.X = vector.At(0);
+            this.Y = vector.At(1);
+            this.Z = vector.At(2);
+            this.W = vector.At(3);
         }
 
         /// <summary>
@@ -203,7 +206,7 @@ namespace MathNet.Spatial.Projective
             // ReSharper disable once CompareOfFloatsByEqualityOperator
             if (this.W != 0)
             {
-                return new Vector3D(this.X / this.W, this.X / this.W, this.X / this.W);
+                return new Vector3D(this.X / this.W, this.Y / this.W, this.Z / this.W);
             }
 
             return Vector3D.NaN;


### PR DESCRIPTION
Removed links that are dead from field comments.
Fixed constructor that take Vector argument (W component was incorrect).  Also replaced :this(x,y,z,w) with assignments in the constructor body, since you must check vector length before calling this(x,y,z,w).
Fixed ToVector3D().  Copy/paste error  (all components were this.X).