### PR TITLE
Increase PolyLine performance when indexing Vertices

### DIFF
--- a/src/Spatial/Euclidean/PolyLine2D.cs
+++ b/src/Spatial/Euclidean/PolyLine2D.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using HashCode = MathNet.Spatial.Internals.HashCode;
@@ -15,7 +16,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Internal storage for the points
         /// </summary>
-        private readonly List<Point2D> points;
+        private readonly ReadOnlyCollection<Point2D> points;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolyLine2D"/> class.
@@ -24,7 +25,7 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="points">A list of points.</param>
         public PolyLine2D(IEnumerable<Point2D> points)
         {
-            this.points = new List<Point2D>(points);
+            this.points = new List<Point2D>(points).AsReadOnly();
         }
 
         /// <summary>
@@ -40,16 +41,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Gets a list of vertices
         /// </summary>
-        public IEnumerable<Point2D> Vertices
-        {
-            get
-            {
-                foreach (var point in this.points)
-                {
-                    yield return point;
-                }
-            }
-        }
+        public IReadOnlyList<Point2D> Vertices => this.points;
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.

--- a/src/Spatial/Euclidean/PolyLine3D.cs
+++ b/src/Spatial/Euclidean/PolyLine3D.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using HashCode = MathNet.Spatial.Internals.HashCode;
@@ -14,7 +15,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// An internal list of points
         /// </summary>
-        private readonly List<Point3D> points;
+        private readonly ReadOnlyCollection<Point3D> points;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolyLine3D"/> class.
@@ -23,7 +24,7 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="points">A list of points.</param>
         public PolyLine3D(IEnumerable<Point3D> points)
         {
-            this.points = new List<Point3D>(points);
+            this.points = new List<Point3D>(points).AsReadOnly();
         }
 
         /// <summary>
@@ -39,16 +40,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Gets a list of vertices
         /// </summary>
-        public IEnumerable<Point3D> Vertices
-        {
-            get
-            {
-                foreach (var point in this.points)
-                {
-                    yield return point;
-                }
-            }
-        }
+        public IReadOnlyList<Point3D> Vertices => this.points;
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.


### PR DESCRIPTION
Expose `IReadOnlyList<T>` instead of `IEnumerable<T>` for `PolyLine.Vertices`

This change allows external methods to index or operate on the vertices
without consuming additional memory by using `ToList()` or `ToArray()` or enumerating the entire collection
multiple times. This change still ensures that the internal list is immutable.

I don't think this is a breaking changes because `IReadOnlyList<T>` implements `IEnumerable<T>`, so anything that relies on `IEnumerable<T>` will still work.

This is implemented by using `ReadOnlyCollection<T>` internally instead of `List<T>`.

I think the same change would be appropriate for `Polygon2D` too but I'm not sure if there was a specific reason for using a custom implementation of `ImmutableList<T>` instead of `ReadOnlyCollection<T>`.