### PR TITLE
Namespace fixes and cleanup

### DIFF
--- a/src/Spatial.Tests/Euclidean/Circle2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Circle2DTests.cs
@@ -2,7 +2,7 @@
 using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class Circle2DTests

--- a/src/Spatial.Tests/Euclidean/Circle3DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Circle3DTests.cs
@@ -4,7 +4,7 @@ using System;
 using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class Circle3DTests

--- a/src/Spatial.Tests/Euclidean/CoordinateSystemTest.cs
+++ b/src/Spatial.Tests/Euclidean/CoordinateSystemTest.cs
@@ -1,12 +1,11 @@
-﻿using MathNet.Spatial.Euclidean;
+﻿using System;
+using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     // ReSharper disable InconsistentNaming
-    using System;
-
     [TestFixture]
     public class CoordinateSystemTest
     {

--- a/src/Spatial.Tests/Euclidean/Line2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Line2DTests.cs
@@ -3,7 +3,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class Line2DTests

--- a/src/Spatial.Tests/Euclidean/Line3DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Line3DTests.cs
@@ -3,7 +3,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class Line3DTests

--- a/src/Spatial.Tests/Euclidean/LineSegment2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/LineSegment2DTests.cs
@@ -3,7 +3,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class LineSegment2DTests

--- a/src/Spatial.Tests/Euclidean/LineSegment3DTests.cs
+++ b/src/Spatial.Tests/Euclidean/LineSegment3DTests.cs
@@ -3,7 +3,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     /// <summary>
     /// Tests for LineSegment3D

--- a/src/Spatial.Tests/Euclidean/PlaneTest.cs
+++ b/src/Spatial.Tests/Euclidean/PlaneTest.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class PlaneTest

--- a/src/Spatial.Tests/Euclidean/Point2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Point2DTests.cs
@@ -9,7 +9,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     public class Point2DTests
     {

--- a/src/Spatial.Tests/Euclidean/Point3DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Point3DTests.cs
@@ -7,7 +7,7 @@ using System.Xml.Serialization;
 using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class Point3DTests

--- a/src/Spatial.Tests/Euclidean/PolyLine2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/PolyLine2DTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class PolyLine2DTests

--- a/src/Spatial.Tests/Euclidean/PolyLine3DTests.cs
+++ b/src/Spatial.Tests/Euclidean/PolyLine3DTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class PolyLine3DTests

--- a/src/Spatial.Tests/Euclidean/Polygon2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Polygon2DTests.cs
@@ -5,7 +5,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class Polygon2DTests

--- a/src/Spatial.Tests/Euclidean/QuaternionTests.cs
+++ b/src/Spatial.Tests/Euclidean/QuaternionTests.cs
@@ -6,7 +6,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     /// <summary>
     /// Complex32 tests.

--- a/src/Spatial.Tests/Euclidean/Ray3DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Ray3DTests.cs
@@ -3,7 +3,7 @@
 using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class Ray3DTests

--- a/src/Spatial.Tests/Euclidean/UnitVector3DTests.cs
+++ b/src/Spatial.Tests/Euclidean/UnitVector3DTests.cs
@@ -7,7 +7,7 @@ using System.Xml.Serialization;
 using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class UnitVector3DTests

--- a/src/Spatial.Tests/Euclidean/Vector2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Vector2DTests.cs
@@ -9,7 +9,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     public class Vector2DTests
     {

--- a/src/Spatial.Tests/Euclidean/Vector3DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Vector3DTests.cs
@@ -8,7 +8,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Euclidean
+namespace MathNet.Spatial.Tests.Euclidean
 {
     [TestFixture]
     public class Vector3DTests

--- a/src/Spatial.Tests/Helpers/AssertGeometry.cs
+++ b/src/Spatial.Tests/Helpers/AssertGeometry.cs
@@ -2,7 +2,7 @@ using MathNet.Numerics.LinearAlgebra;
 using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests
+namespace MathNet.Spatial.Tests
 {
     public static class AssertGeometry
     {

--- a/src/Spatial.Tests/Helpers/AssertXml.cs
+++ b/src/Spatial.Tests/Helpers/AssertXml.cs
@@ -7,7 +7,7 @@ using System.Xml.Linq;
 using System.Xml.Serialization;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests
+namespace MathNet.Spatial.Tests
 {
     public static class AssertXml
     {

--- a/src/Spatial.Tests/Helpers/AssertXmlTests.cs
+++ b/src/Spatial.Tests/Helpers/AssertXmlTests.cs
@@ -5,7 +5,7 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests
+namespace MathNet.Spatial.Tests
 {
     public class AssertXmlTests
     {

--- a/src/Spatial.Tests/ParserTests.cs
+++ b/src/Spatial.Tests/ParserTests.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Globalization;
 using System.Text.RegularExpressions;
-using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
+using MathNet.Spatial.Euclidean;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests
+namespace MathNet.Spatial.Tests
 {
     public class ParserTests
     {

--- a/src/Spatial.Tests/Serialization/BinaryFormatterTests.cs
+++ b/src/Spatial.Tests/Serialization/BinaryFormatterTests.cs
@@ -5,7 +5,7 @@ using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests
+namespace MathNet.Spatial.Tests.Serialization
 {
     public class BinaryFormatterTests
     {

--- a/src/Spatial.Tests/Serialization/DataContractTests.cs
+++ b/src/Spatial.Tests/Serialization/DataContractTests.cs
@@ -5,10 +5,9 @@ using System.Runtime.Serialization;
 using System.Xml;
 using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
-using MathNet.Spatial.UnitTests;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.Serialization.Xml.UnitTests
+namespace MathNet.Spatial.Tests.Serialization
 {
     public class DataContractTests
     {

--- a/src/Spatial.Tests/Serialization/JsonTests.cs
+++ b/src/Spatial.Tests/Serialization/JsonTests.cs
@@ -1,11 +1,10 @@
 ﻿using System.Linq;
 using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
-using MathNet.Spatial.UnitTests;
 using Newtonsoft.Json;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.Serialization.Xml.UnitTests
+namespace MathNet.Spatial.Tests.Serialization
 {
     public class JsonTests
     {

--- a/src/Spatial.Tests/Serialization/ProtobufnetTests.cs
+++ b/src/Spatial.Tests/Serialization/ProtobufnetTests.cs
@@ -2,12 +2,11 @@
 using System.Linq;
 using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
-using MathNet.Spatial.UnitTests;
 using NUnit.Framework;
 using ProtoBuf;
 using ProtoBuf.Meta;
 
-namespace MathNet.Spatial.Serialization.Xml.UnitTests
+namespace MathNet.Spatial.Tests.Serialization
 {
     public class ProtobufNetTests
     {

--- a/src/Spatial.Tests/Serialization/XmlSerializaerTests.cs
+++ b/src/Spatial.Tests/Serialization/XmlSerializaerTests.cs
@@ -1,10 +1,9 @@
 ﻿using System.Linq;
 using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
-using MathNet.Spatial.UnitTests;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.Serialization.Xml.UnitTests
+namespace MathNet.Spatial.Tests.Serialization
 {
     public class XmlSerializaerTests
     {

--- a/src/Spatial.Tests/Units/AngleTests.cs
+++ b/src/Spatial.Tests/Units/AngleTests.cs
@@ -7,7 +7,7 @@ using System.Xml.Serialization;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
 
-namespace MathNet.Spatial.UnitTests.Units
+namespace MathNet.Spatial.Tests.Units
 {
     public class AngleTests
     {

--- a/src/Spatial/Euclidean/Circle2D.cs
+++ b/src/Spatial/Euclidean/Circle2D.cs
@@ -7,7 +7,7 @@ namespace MathNet.Spatial.Euclidean
     /// <summary>
     /// Describes a standard 2 dimensional circle
     /// </summary>
-    public readonly struct Circle2D : IEquatable<Circle2D>
+    public struct Circle2D : IEquatable<Circle2D>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Circle2D"/> struct.
@@ -17,8 +17,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="radius">The radius of the circle</param>
         public Circle2D(Point2D center, double radius)
         {
-            Center = center;
-            Radius = radius;
+            this.Center = center;
+            this.Radius = radius;
         }
 
         /// <summary>
@@ -35,19 +35,19 @@ namespace MathNet.Spatial.Euclidean
         /// Gets the circumference of the circle
         /// </summary>
         [Pure]
-        public double Circumference => 2 * Radius * Math.PI;
+        public double Circumference => 2 * this.Radius * Math.PI;
 
         /// <summary>
         /// Gets the diameter of the circle
         /// </summary>
         [Pure]
-        public double Diameter => 2 * Radius;
+        public double Diameter => 2 * this.Radius;
 
         /// <summary>
         /// Gets the area of the circle
         /// </summary>
         [Pure]
-        public double Area => Radius * Radius * Math.PI;
+        public double Area => this.Radius * this.Radius * Math.PI;
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified circles is equal.
@@ -140,19 +140,19 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(c.Radius - Radius) < tolerance && Center.Equals(c.Center, tolerance);
+            return Math.Abs(c.Radius - this.Radius) < tolerance && this.Center.Equals(c.Center, tolerance);
         }
 
         /// <inheritdoc />
         [Pure]
-        public bool Equals(Circle2D c) => Radius.Equals(c.Radius) && Center.Equals(c.Center);
+        public bool Equals(Circle2D c) => this.Radius.Equals(c.Radius) && this.Center.Equals(c.Center);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Circle2D c && Equals(c);
+        public override bool Equals(object obj) => obj is Circle2D c && this.Equals(c);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(Center, Radius);
+        public override int GetHashCode() => HashCode.Combine(this.Center, this.Radius);
     }
 }

--- a/src/Spatial/Euclidean/Circle2D.cs
+++ b/src/Spatial/Euclidean/Circle2D.cs
@@ -7,7 +7,7 @@ namespace MathNet.Spatial.Euclidean
     /// <summary>
     /// Describes a standard 2 dimensional circle
     /// </summary>
-    public struct Circle2D : IEquatable<Circle2D>
+    public readonly struct Circle2D : IEquatable<Circle2D>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="Circle2D"/> struct.
@@ -17,8 +17,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="radius">The radius of the circle</param>
         public Circle2D(Point2D center, double radius)
         {
-            this.Center = center;
-            this.Radius = radius;
+            Center = center;
+            Radius = radius;
         }
 
         /// <summary>
@@ -35,19 +35,19 @@ namespace MathNet.Spatial.Euclidean
         /// Gets the circumference of the circle
         /// </summary>
         [Pure]
-        public double Circumference => 2 * this.Radius * Math.PI;
+        public double Circumference => 2 * Radius * Math.PI;
 
         /// <summary>
         /// Gets the diameter of the circle
         /// </summary>
         [Pure]
-        public double Diameter => 2 * this.Radius;
+        public double Diameter => 2 * Radius;
 
         /// <summary>
         /// Gets the area of the circle
         /// </summary>
         [Pure]
-        public double Area => this.Radius * this.Radius * Math.PI;
+        public double Area => Radius * Radius * Math.PI;
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified circles is equal.
@@ -140,19 +140,19 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(c.Radius - this.Radius) < tolerance && this.Center.Equals(c.Center, tolerance);
+            return Math.Abs(c.Radius - Radius) < tolerance && Center.Equals(c.Center, tolerance);
         }
 
         /// <inheritdoc />
         [Pure]
-        public bool Equals(Circle2D c) => this.Radius.Equals(c.Radius) && this.Center.Equals(c.Center);
+        public bool Equals(Circle2D c) => Radius.Equals(c.Radius) && Center.Equals(c.Center);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Circle2D c && this.Equals(c);
+        public override bool Equals(object obj) => obj is Circle2D c && Equals(c);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.Center, this.Radius);
+        public override int GetHashCode() => HashCode.Combine(Center, Radius);
     }
 }

--- a/src/Spatial/Euclidean/Circle3D.cs
+++ b/src/Spatial/Euclidean/Circle3D.cs
@@ -8,7 +8,7 @@ namespace MathNet.Spatial.Euclidean
     /// Describes a 3 dimensional circle
     /// </summary>
     [Serializable]
-    public struct Circle3D : IEquatable<Circle3D>
+    public readonly struct Circle3D : IEquatable<Circle3D>
     {
         /// <summary>
         /// The center of the circle
@@ -34,28 +34,28 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="radius">the radius of the circle</param>
         public Circle3D(Point3D centerPoint, UnitVector3D axis, double radius)
         {
-            this.CenterPoint = centerPoint;
-            this.Axis = axis;
-            this.Radius = radius;
+            CenterPoint = centerPoint;
+            Axis = axis;
+            Radius = radius;
         }
 
         /// <summary>
         /// Gets the diameter of the circle
         /// </summary>
         [Pure]
-        public double Diameter => 2 * this.Radius;
+        public double Diameter => 2 * Radius;
 
         /// <summary>
         /// Gets the circumference of the circle
         /// </summary>
         [Pure]
-        public double Circumference => 2 * Math.PI * this.Radius;
+        public double Circumference => 2 * Math.PI * Radius;
 
         /// <summary>
         /// Gets the area of the circle
         /// </summary>
         [Pure]
-        public double Area => this.Radius * this.Radius * Math.PI;
+        public double Area => Radius * Radius * Math.PI;
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified circles is equal.
@@ -142,26 +142,26 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(c.Radius - this.Radius) < tolerance
-                   && this.Axis.Equals(c.Axis, tolerance)
-                   && this.CenterPoint.Equals(c.CenterPoint, tolerance);
+            return Math.Abs(c.Radius - Radius) < tolerance
+                   && Axis.Equals(c.Axis, tolerance)
+                   && CenterPoint.Equals(c.CenterPoint, tolerance);
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(Circle3D c)
         {
-            return this.CenterPoint.Equals(c.CenterPoint)
-                   && this.Axis.Equals(c.Axis)
-                   && this.Radius.Equals(c.Radius);
+            return CenterPoint.Equals(c.CenterPoint)
+                   && Axis.Equals(c.Axis)
+                   && Radius.Equals(c.Radius);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Circle3D c && this.Equals(c);
+        public override bool Equals(object obj) => obj is Circle3D c && Equals(c);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.CenterPoint, this.Axis, this.Radius);
+        public override int GetHashCode() => HashCode.Combine(CenterPoint, Axis, Radius);
     }
 }

--- a/src/Spatial/Euclidean/Circle3D.cs
+++ b/src/Spatial/Euclidean/Circle3D.cs
@@ -8,7 +8,7 @@ namespace MathNet.Spatial.Euclidean
     /// Describes a 3 dimensional circle
     /// </summary>
     [Serializable]
-    public readonly struct Circle3D : IEquatable<Circle3D>
+    public struct Circle3D : IEquatable<Circle3D>
     {
         /// <summary>
         /// The center of the circle
@@ -34,28 +34,28 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="radius">the radius of the circle</param>
         public Circle3D(Point3D centerPoint, UnitVector3D axis, double radius)
         {
-            CenterPoint = centerPoint;
-            Axis = axis;
-            Radius = radius;
+            this.CenterPoint = centerPoint;
+            this.Axis = axis;
+            this.Radius = radius;
         }
 
         /// <summary>
         /// Gets the diameter of the circle
         /// </summary>
         [Pure]
-        public double Diameter => 2 * Radius;
+        public double Diameter => 2 * this.Radius;
 
         /// <summary>
         /// Gets the circumference of the circle
         /// </summary>
         [Pure]
-        public double Circumference => 2 * Math.PI * Radius;
+        public double Circumference => 2 * Math.PI * this.Radius;
 
         /// <summary>
         /// Gets the area of the circle
         /// </summary>
         [Pure]
-        public double Area => Radius * Radius * Math.PI;
+        public double Area => this.Radius * this.Radius * Math.PI;
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified circles is equal.
@@ -142,26 +142,26 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(c.Radius - Radius) < tolerance
-                   && Axis.Equals(c.Axis, tolerance)
-                   && CenterPoint.Equals(c.CenterPoint, tolerance);
+            return Math.Abs(c.Radius - this.Radius) < tolerance
+                   && this.Axis.Equals(c.Axis, tolerance)
+                   && this.CenterPoint.Equals(c.CenterPoint, tolerance);
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(Circle3D c)
         {
-            return CenterPoint.Equals(c.CenterPoint)
-                   && Axis.Equals(c.Axis)
-                   && Radius.Equals(c.Radius);
+            return this.CenterPoint.Equals(c.CenterPoint)
+                   && this.Axis.Equals(c.Axis)
+                   && this.Radius.Equals(c.Radius);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Circle3D c && Equals(c);
+        public override bool Equals(object obj) => obj is Circle3D c && this.Equals(c);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(CenterPoint, Axis, Radius);
+        public override int GetHashCode() => HashCode.Combine(this.CenterPoint, this.Axis, this.Radius);
     }
 }

--- a/src/Spatial/Euclidean/CoordinateSystem.cs
+++ b/src/Spatial/Euclidean/CoordinateSystem.cs
@@ -71,10 +71,10 @@ namespace MathNet.Spatial.Euclidean
         public CoordinateSystem(Point3D origin, Vector3D xAxis, Vector3D yAxis, Vector3D zAxis)
             : base(4)
         {
-            this.SetColumn(0, new[] { xAxis.X, xAxis.Y, xAxis.Z, 0 });
-            this.SetColumn(1, new[] { yAxis.X, yAxis.Y, yAxis.Z, 0 });
-            this.SetColumn(2, new[] { zAxis.X, zAxis.Y, zAxis.Z, 0 });
-            this.SetColumn(3, new[] { origin.X, origin.Y, origin.Z, 1 });
+            SetColumn(0, new[] { xAxis.X, xAxis.Y, xAxis.Z, 0 });
+            SetColumn(1, new[] { yAxis.X, yAxis.Y, yAxis.Z, 0 });
+            SetColumn(2, new[] { zAxis.X, zAxis.Y, zAxis.Z, 0 });
+            SetColumn(3, new[] { origin.X, origin.Y, origin.Z, 1 });
         }
 
         ////public CoordinateSystem(Vector3D x, Vector3D y, Vector3D z, Vector3D offsetToBase)
@@ -107,7 +107,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var row = this.SubMatrix(0, 3, 0, 1).ToRowMajorArray();
+                var row = SubMatrix(0, 3, 0, 1).ToRowMajorArray();
                 return new Vector3D(row[0], row[1], row[2]);
             }
         }
@@ -119,7 +119,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var row = this.SubMatrix(0, 3, 1, 1).ToRowMajorArray();
+                var row = SubMatrix(0, 3, 1, 1).ToRowMajorArray();
                 return new Vector3D(row[0], row[1], row[2]);
             }
         }
@@ -131,7 +131,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var row = this.SubMatrix(0, 3, 2, 1).ToRowMajorArray();
+                var row = SubMatrix(0, 3, 2, 1).ToRowMajorArray();
                 return new Vector3D(row[0], row[1], row[2]);
             }
         }
@@ -143,7 +143,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var row = this.SubMatrix(0, 3, 3, 1).ToRowMajorArray();
+                var row = SubMatrix(0, 3, 3, 1).ToRowMajorArray();
                 return new Point3D(row[0], row[1], row[2]);
             }
         }
@@ -153,7 +153,7 @@ namespace MathNet.Spatial.Euclidean
         /// </summary>
         public Vector3D OffsetToBase
         {
-            get { return this.Origin.ToVector3D(); }
+            get { return Origin.ToVector3D(); }
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var matrix = Build.DenseOfColumnVectors(this.XAxis.ToVector(), this.YAxis.ToVector(), this.ZAxis.ToVector());
+                var matrix = Build.DenseOfColumnVectors(XAxis.ToVector(), YAxis.ToVector(), ZAxis.ToVector());
                 var cs = new CoordinateSystem(this);
                 cs.SetRotationSubMatrix(matrix.Transpose());
                 return cs;
@@ -379,10 +379,10 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A coordinate system with reset rotation</returns>
         public CoordinateSystem ResetRotations()
         {
-            var x = this.XAxis.Length * UnitVector3D.XAxis;
-            var y = this.YAxis.Length * UnitVector3D.YAxis;
-            var z = this.ZAxis.Length * UnitVector3D.ZAxis;
-            return new CoordinateSystem(x, y, z, this.Origin);
+            var x = XAxis.Length * UnitVector3D.XAxis;
+            var y = YAxis.Length * UnitVector3D.YAxis;
+            var z = ZAxis.Length * UnitVector3D.ZAxis;
+            return new CoordinateSystem(x, y, z, Origin);
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A translated coordinate system</returns>
         public CoordinateSystem OffsetBy(Vector3D v)
         {
-            return new CoordinateSystem(this.Origin + v, this.XAxis, this.YAxis, this.ZAxis);
+            return new CoordinateSystem(Origin + v, XAxis, YAxis, ZAxis);
         }
 
         /// <summary>
@@ -427,7 +427,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A translated coordinate system</returns>
         public CoordinateSystem OffsetBy(UnitVector3D v)
         {
-            return new CoordinateSystem(this.Origin + v, this.XAxis, this.YAxis, this.ZAxis);
+            return new CoordinateSystem(Origin + v, XAxis, YAxis, ZAxis);
         }
 
         /// <summary>
@@ -441,8 +441,8 @@ namespace MathNet.Spatial.Euclidean
             var uv = r.Direction;
 
             // The position and the vector are transformed
-            var baseChangeMatrix = this.BaseChangeMatrix;
-            var point = baseChangeMatrix.Transform(p) + this.OffsetToBase;
+            var baseChangeMatrix = BaseChangeMatrix;
+            var point = baseChangeMatrix.Transform(p) + OffsetToBase;
             var direction = uv.TransformBy(baseChangeMatrix);
             return new Ray3D(point, direction);
         }
@@ -454,8 +454,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a transformed point</returns>
         public Point3D TransformToCoordSys(Point3D p)
         {
-            var baseChangeMatrix = this.BaseChangeMatrix;
-            var point = baseChangeMatrix.Transform(p) + this.OffsetToBase;
+            var baseChangeMatrix = BaseChangeMatrix;
+            var point = baseChangeMatrix.Transform(p) + OffsetToBase;
             return point;
         }
 
@@ -470,8 +470,8 @@ namespace MathNet.Spatial.Euclidean
             var uv = r.Direction;
 
             // The position and the vector are transformed
-            var point = this.BaseChangeMatrix.Invert().Transform(p) + this.OffsetToBase;
-            var direction = this.BaseChangeMatrix.Invert().Transform(uv);
+            var point = BaseChangeMatrix.Invert().Transform(p) + OffsetToBase;
+            var direction = BaseChangeMatrix.Invert().Transform(uv);
             return new Ray3D(point, direction);
         }
 
@@ -482,7 +482,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a transformed point</returns>
         public Point3D TransformFromCoordSys(Point3D p)
         {
-            var point = this.BaseChangeMatrix.Invert().Transform(p) + this.OffsetToBase;
+            var point = BaseChangeMatrix.Invert().Transform(p) + OffsetToBase;
             return point;
         }
 
@@ -503,7 +503,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a coordinate system</returns>
         public CoordinateSystem SetTranslation(Vector3D v)
         {
-            return new CoordinateSystem(v.ToPoint3D(), this.XAxis, this.YAxis, this.ZAxis);
+            return new CoordinateSystem(v.ToPoint3D(), XAxis, YAxis, ZAxis);
         }
 
         /// <summary>
@@ -523,7 +523,7 @@ namespace MathNet.Spatial.Euclidean
         public Vector3D Transform(Vector3D v)
         {
             var v3 = Vector<double>.Build.Dense(new[] { v.X, v.Y, v.Z });
-            this.GetRotationSubMatrix().Multiply(v3, v3);
+            GetRotationSubMatrix().Multiply(v3, v3);
             return new Vector3D(v3[0], v3[1], v3[2]);
         }
 
@@ -535,7 +535,7 @@ namespace MathNet.Spatial.Euclidean
         public Vector3D Transform(UnitVector3D v)
         {
             var v3 = Vector<double>.Build.Dense(new[] { v.X, v.Y, v.Z });
-            this.GetRotationSubMatrix().Multiply(v3, v3);
+            GetRotationSubMatrix().Multiply(v3, v3);
             return new Vector3D(v3[0], v3[1], v3[2]);
         }
 
@@ -547,7 +547,7 @@ namespace MathNet.Spatial.Euclidean
         public Point3D Transform(Point3D p)
         {
             var v4 = Vector<double>.Build.Dense(new[] { p.X, p.Y, p.Z, 1 });
-            this.Multiply(v4, v4);
+            Multiply(v4, v4);
             return new Point3D(v4[0], v4[1], v4[2]);
         }
 
@@ -558,7 +558,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A transformed coordinate system</returns>
         public CoordinateSystem Transform(CoordinateSystem cs)
         {
-            return new CoordinateSystem(this.Multiply(cs));
+            return new CoordinateSystem(Multiply(cs));
         }
 
         /// <summary>
@@ -568,7 +568,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>The transformed line segment</returns>
         public LineSegment3D Transform(LineSegment3D l)
         {
-            return new LineSegment3D(this.Transform(l.StartPoint), this.Transform(l.EndPoint));
+            return new LineSegment3D(Transform(l.StartPoint), Transform(l.EndPoint));
         }
 
         /// <summary>
@@ -578,7 +578,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A transformed ray</returns>
         public Ray3D Transform(Ray3D ray)
         {
-            return new Ray3D(this.Transform(ray.ThroughPoint), this.Transform(ray.Direction));
+            return new Ray3D(Transform(ray.ThroughPoint), Transform(ray.Direction));
         }
 
         /// <summary>
@@ -607,7 +607,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>An inverted coordinate system</returns>
         public CoordinateSystem Invert()
         {
-            return new CoordinateSystem(this.Inverse());
+            return new CoordinateSystem(Inverse());
         }
 
         /// <summary>
@@ -619,14 +619,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(CoordinateSystem other, double tolerance)
         {
-            if (this.Values.Length != other?.Values.Length)
+            if (Values.Length != other?.Values.Length)
             {
                 return false;
             }
 
-            for (var i = 0; i < this.Values.Length; i++)
+            for (var i = 0; i < Values.Length; i++)
             {
-                if (Math.Abs(this.Values[i] - other.Values[i]) > tolerance)
+                if (Math.Abs(Values[i] - other.Values[i]) > tolerance)
                 {
                     return false;
                 }
@@ -639,15 +639,15 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(CoordinateSystem other)
         {
-            if (this.Values.Length != other?.Values.Length)
+            if (Values.Length != other?.Values.Length)
             {
                 return false;
             }
 
-            for (var i = 0; i < this.Values.Length; i++)
+            for (var i = 0; i < Values.Length; i++)
             {
                 // ReSharper disable once CompareOfFloatsByEqualityOperator
-                if (this.Values[i] != other.Values[i])
+                if (Values[i] != other.Values[i])
                 {
                     return false;
                 }
@@ -665,12 +665,12 @@ namespace MathNet.Spatial.Euclidean
                 return false;
             }
 
-            return obj is CoordinateSystem cs && this.Equals(cs);
+            return obj is CoordinateSystem cs && Equals(cs);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.CombineMany(this.Values);
+        public override int GetHashCode() => HashCode.CombineMany(Values);
 
         /// <summary>
         /// Returns a string representation of the coordinate system
@@ -678,7 +678,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a string</returns>
         public new string ToString()
         {
-            return $"Origin: {this.Origin}, XAxis: {this.XAxis}, YAxis: {this.YAxis}, ZAxis: {this.ZAxis}";
+            return $"Origin: {Origin}, XAxis: {XAxis}, YAxis: {YAxis}, ZAxis: {ZAxis}";
         }
 
         /// <inheritdoc />
@@ -693,25 +693,25 @@ namespace MathNet.Spatial.Euclidean
             var e = (XElement)XNode.ReadFrom(reader);
 
             var xAxis = Vector3D.ReadFrom(e.SingleElementReader("XAxis"));
-            this.SetColumn(0, new[] { xAxis.X, xAxis.Y, xAxis.Z, 0 });
+            SetColumn(0, new[] { xAxis.X, xAxis.Y, xAxis.Z, 0 });
 
             var yAxis = Vector3D.ReadFrom(e.SingleElementReader("YAxis"));
-            this.SetColumn(1, new[] { yAxis.X, yAxis.Y, yAxis.Z, 0 });
+            SetColumn(1, new[] { yAxis.X, yAxis.Y, yAxis.Z, 0 });
 
             var zAxis = Vector3D.ReadFrom(e.SingleElementReader("ZAxis"));
-            this.SetColumn(2, new[] { zAxis.X, zAxis.Y, zAxis.Z, 0 });
+            SetColumn(2, new[] { zAxis.X, zAxis.Y, zAxis.Z, 0 });
 
             var origin = Point3D.ReadFrom(e.SingleElementReader("Origin"));
-            this.SetColumn(3, new[] { origin.X, origin.Y, origin.Z, 1 });
+            SetColumn(3, new[] { origin.X, origin.Y, origin.Z, 1 });
         }
 
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteElement("Origin", this.Origin);
-            writer.WriteElement("XAxis", this.XAxis);
-            writer.WriteElement("YAxis", this.YAxis);
-            writer.WriteElement("ZAxis", this.ZAxis);
+            writer.WriteElement("Origin", Origin);
+            writer.WriteElement("XAxis", XAxis);
+            writer.WriteElement("YAxis", YAxis);
+            writer.WriteElement("ZAxis", ZAxis);
         }
     }
 }

--- a/src/Spatial/Euclidean/CoordinateSystem.cs
+++ b/src/Spatial/Euclidean/CoordinateSystem.cs
@@ -71,10 +71,10 @@ namespace MathNet.Spatial.Euclidean
         public CoordinateSystem(Point3D origin, Vector3D xAxis, Vector3D yAxis, Vector3D zAxis)
             : base(4)
         {
-            SetColumn(0, new[] { xAxis.X, xAxis.Y, xAxis.Z, 0 });
-            SetColumn(1, new[] { yAxis.X, yAxis.Y, yAxis.Z, 0 });
-            SetColumn(2, new[] { zAxis.X, zAxis.Y, zAxis.Z, 0 });
-            SetColumn(3, new[] { origin.X, origin.Y, origin.Z, 1 });
+            this.SetColumn(0, new[] { xAxis.X, xAxis.Y, xAxis.Z, 0 });
+            this.SetColumn(1, new[] { yAxis.X, yAxis.Y, yAxis.Z, 0 });
+            this.SetColumn(2, new[] { zAxis.X, zAxis.Y, zAxis.Z, 0 });
+            this.SetColumn(3, new[] { origin.X, origin.Y, origin.Z, 1 });
         }
 
         ////public CoordinateSystem(Vector3D x, Vector3D y, Vector3D z, Vector3D offsetToBase)
@@ -107,7 +107,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var row = SubMatrix(0, 3, 0, 1).ToRowMajorArray();
+                var row = this.SubMatrix(0, 3, 0, 1).ToRowMajorArray();
                 return new Vector3D(row[0], row[1], row[2]);
             }
         }
@@ -119,7 +119,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var row = SubMatrix(0, 3, 1, 1).ToRowMajorArray();
+                var row = this.SubMatrix(0, 3, 1, 1).ToRowMajorArray();
                 return new Vector3D(row[0], row[1], row[2]);
             }
         }
@@ -131,7 +131,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var row = SubMatrix(0, 3, 2, 1).ToRowMajorArray();
+                var row = this.SubMatrix(0, 3, 2, 1).ToRowMajorArray();
                 return new Vector3D(row[0], row[1], row[2]);
             }
         }
@@ -143,7 +143,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var row = SubMatrix(0, 3, 3, 1).ToRowMajorArray();
+                var row = this.SubMatrix(0, 3, 3, 1).ToRowMajorArray();
                 return new Point3D(row[0], row[1], row[2]);
             }
         }
@@ -153,7 +153,7 @@ namespace MathNet.Spatial.Euclidean
         /// </summary>
         public Vector3D OffsetToBase
         {
-            get { return Origin.ToVector3D(); }
+            get { return this.Origin.ToVector3D(); }
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                var matrix = Build.DenseOfColumnVectors(XAxis.ToVector(), YAxis.ToVector(), ZAxis.ToVector());
+                var matrix = Build.DenseOfColumnVectors(this.XAxis.ToVector(), this.YAxis.ToVector(), this.ZAxis.ToVector());
                 var cs = new CoordinateSystem(this);
                 cs.SetRotationSubMatrix(matrix.Transpose());
                 return cs;
@@ -379,10 +379,10 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A coordinate system with reset rotation</returns>
         public CoordinateSystem ResetRotations()
         {
-            var x = XAxis.Length * UnitVector3D.XAxis;
-            var y = YAxis.Length * UnitVector3D.YAxis;
-            var z = ZAxis.Length * UnitVector3D.ZAxis;
-            return new CoordinateSystem(x, y, z, Origin);
+            var x = this.XAxis.Length * UnitVector3D.XAxis;
+            var y = this.YAxis.Length * UnitVector3D.YAxis;
+            var z = this.ZAxis.Length * UnitVector3D.ZAxis;
+            return new CoordinateSystem(x, y, z, this.Origin);
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A translated coordinate system</returns>
         public CoordinateSystem OffsetBy(Vector3D v)
         {
-            return new CoordinateSystem(Origin + v, XAxis, YAxis, ZAxis);
+            return new CoordinateSystem(this.Origin + v, this.XAxis, this.YAxis, this.ZAxis);
         }
 
         /// <summary>
@@ -427,7 +427,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A translated coordinate system</returns>
         public CoordinateSystem OffsetBy(UnitVector3D v)
         {
-            return new CoordinateSystem(Origin + v, XAxis, YAxis, ZAxis);
+            return new CoordinateSystem(this.Origin + v, this.XAxis, this.YAxis, this.ZAxis);
         }
 
         /// <summary>
@@ -441,8 +441,8 @@ namespace MathNet.Spatial.Euclidean
             var uv = r.Direction;
 
             // The position and the vector are transformed
-            var baseChangeMatrix = BaseChangeMatrix;
-            var point = baseChangeMatrix.Transform(p) + OffsetToBase;
+            var baseChangeMatrix = this.BaseChangeMatrix;
+            var point = baseChangeMatrix.Transform(p) + this.OffsetToBase;
             var direction = uv.TransformBy(baseChangeMatrix);
             return new Ray3D(point, direction);
         }
@@ -454,8 +454,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a transformed point</returns>
         public Point3D TransformToCoordSys(Point3D p)
         {
-            var baseChangeMatrix = BaseChangeMatrix;
-            var point = baseChangeMatrix.Transform(p) + OffsetToBase;
+            var baseChangeMatrix = this.BaseChangeMatrix;
+            var point = baseChangeMatrix.Transform(p) + this.OffsetToBase;
             return point;
         }
 
@@ -470,8 +470,8 @@ namespace MathNet.Spatial.Euclidean
             var uv = r.Direction;
 
             // The position and the vector are transformed
-            var point = BaseChangeMatrix.Invert().Transform(p) + OffsetToBase;
-            var direction = BaseChangeMatrix.Invert().Transform(uv);
+            var point = this.BaseChangeMatrix.Invert().Transform(p) + this.OffsetToBase;
+            var direction = this.BaseChangeMatrix.Invert().Transform(uv);
             return new Ray3D(point, direction);
         }
 
@@ -482,7 +482,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a transformed point</returns>
         public Point3D TransformFromCoordSys(Point3D p)
         {
-            var point = BaseChangeMatrix.Invert().Transform(p) + OffsetToBase;
+            var point = this.BaseChangeMatrix.Invert().Transform(p) + this.OffsetToBase;
             return point;
         }
 
@@ -503,7 +503,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a coordinate system</returns>
         public CoordinateSystem SetTranslation(Vector3D v)
         {
-            return new CoordinateSystem(v.ToPoint3D(), XAxis, YAxis, ZAxis);
+            return new CoordinateSystem(v.ToPoint3D(), this.XAxis, this.YAxis, this.ZAxis);
         }
 
         /// <summary>
@@ -523,7 +523,7 @@ namespace MathNet.Spatial.Euclidean
         public Vector3D Transform(Vector3D v)
         {
             var v3 = Vector<double>.Build.Dense(new[] { v.X, v.Y, v.Z });
-            GetRotationSubMatrix().Multiply(v3, v3);
+            this.GetRotationSubMatrix().Multiply(v3, v3);
             return new Vector3D(v3[0], v3[1], v3[2]);
         }
 
@@ -535,7 +535,7 @@ namespace MathNet.Spatial.Euclidean
         public Vector3D Transform(UnitVector3D v)
         {
             var v3 = Vector<double>.Build.Dense(new[] { v.X, v.Y, v.Z });
-            GetRotationSubMatrix().Multiply(v3, v3);
+            this.GetRotationSubMatrix().Multiply(v3, v3);
             return new Vector3D(v3[0], v3[1], v3[2]);
         }
 
@@ -547,7 +547,7 @@ namespace MathNet.Spatial.Euclidean
         public Point3D Transform(Point3D p)
         {
             var v4 = Vector<double>.Build.Dense(new[] { p.X, p.Y, p.Z, 1 });
-            Multiply(v4, v4);
+            this.Multiply(v4, v4);
             return new Point3D(v4[0], v4[1], v4[2]);
         }
 
@@ -558,7 +558,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A transformed coordinate system</returns>
         public CoordinateSystem Transform(CoordinateSystem cs)
         {
-            return new CoordinateSystem(Multiply(cs));
+            return new CoordinateSystem(this.Multiply(cs));
         }
 
         /// <summary>
@@ -568,7 +568,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>The transformed line segment</returns>
         public LineSegment3D Transform(LineSegment3D l)
         {
-            return new LineSegment3D(Transform(l.StartPoint), Transform(l.EndPoint));
+            return new LineSegment3D(this.Transform(l.StartPoint), this.Transform(l.EndPoint));
         }
 
         /// <summary>
@@ -578,7 +578,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A transformed ray</returns>
         public Ray3D Transform(Ray3D ray)
         {
-            return new Ray3D(Transform(ray.ThroughPoint), Transform(ray.Direction));
+            return new Ray3D(this.Transform(ray.ThroughPoint), this.Transform(ray.Direction));
         }
 
         /// <summary>
@@ -607,7 +607,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>An inverted coordinate system</returns>
         public CoordinateSystem Invert()
         {
-            return new CoordinateSystem(Inverse());
+            return new CoordinateSystem(this.Inverse());
         }
 
         /// <summary>
@@ -619,14 +619,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(CoordinateSystem other, double tolerance)
         {
-            if (Values.Length != other?.Values.Length)
+            if (this.Values.Length != other?.Values.Length)
             {
                 return false;
             }
 
-            for (var i = 0; i < Values.Length; i++)
+            for (var i = 0; i < this.Values.Length; i++)
             {
-                if (Math.Abs(Values[i] - other.Values[i]) > tolerance)
+                if (Math.Abs(this.Values[i] - other.Values[i]) > tolerance)
                 {
                     return false;
                 }
@@ -639,15 +639,15 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(CoordinateSystem other)
         {
-            if (Values.Length != other?.Values.Length)
+            if (this.Values.Length != other?.Values.Length)
             {
                 return false;
             }
 
-            for (var i = 0; i < Values.Length; i++)
+            for (var i = 0; i < this.Values.Length; i++)
             {
                 // ReSharper disable once CompareOfFloatsByEqualityOperator
-                if (Values[i] != other.Values[i])
+                if (this.Values[i] != other.Values[i])
                 {
                     return false;
                 }
@@ -665,12 +665,12 @@ namespace MathNet.Spatial.Euclidean
                 return false;
             }
 
-            return obj is CoordinateSystem cs && Equals(cs);
+            return obj is CoordinateSystem cs && this.Equals(cs);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.CombineMany(Values);
+        public override int GetHashCode() => HashCode.CombineMany(this.Values);
 
         /// <summary>
         /// Returns a string representation of the coordinate system
@@ -678,7 +678,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a string</returns>
         public new string ToString()
         {
-            return $"Origin: {Origin}, XAxis: {XAxis}, YAxis: {YAxis}, ZAxis: {ZAxis}";
+            return $"Origin: {this.Origin}, XAxis: {this.XAxis}, YAxis: {this.YAxis}, ZAxis: {this.ZAxis}";
         }
 
         /// <inheritdoc />
@@ -693,25 +693,25 @@ namespace MathNet.Spatial.Euclidean
             var e = (XElement)XNode.ReadFrom(reader);
 
             var xAxis = Vector3D.ReadFrom(e.SingleElementReader("XAxis"));
-            SetColumn(0, new[] { xAxis.X, xAxis.Y, xAxis.Z, 0 });
+            this.SetColumn(0, new[] { xAxis.X, xAxis.Y, xAxis.Z, 0 });
 
             var yAxis = Vector3D.ReadFrom(e.SingleElementReader("YAxis"));
-            SetColumn(1, new[] { yAxis.X, yAxis.Y, yAxis.Z, 0 });
+            this.SetColumn(1, new[] { yAxis.X, yAxis.Y, yAxis.Z, 0 });
 
             var zAxis = Vector3D.ReadFrom(e.SingleElementReader("ZAxis"));
-            SetColumn(2, new[] { zAxis.X, zAxis.Y, zAxis.Z, 0 });
+            this.SetColumn(2, new[] { zAxis.X, zAxis.Y, zAxis.Z, 0 });
 
             var origin = Point3D.ReadFrom(e.SingleElementReader("Origin"));
-            SetColumn(3, new[] { origin.X, origin.Y, origin.Z, 1 });
+            this.SetColumn(3, new[] { origin.X, origin.Y, origin.Z, 1 });
         }
 
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteElement("Origin", Origin);
-            writer.WriteElement("XAxis", XAxis);
-            writer.WriteElement("YAxis", YAxis);
-            writer.WriteElement("ZAxis", ZAxis);
+            writer.WriteElement("Origin", this.Origin);
+            writer.WriteElement("XAxis", this.XAxis);
+            writer.WriteElement("YAxis", this.YAxis);
+            writer.WriteElement("ZAxis", this.ZAxis);
         }
     }
 }

--- a/src/Spatial/Euclidean/EulerAngles.cs
+++ b/src/Spatial/Euclidean/EulerAngles.cs
@@ -9,7 +9,7 @@ namespace MathNet.Spatial.Euclidean
     /// A means of representing spatial orientation of any reference frame.
     /// More information can be found https://en.wikipedia.org/wiki/Euler_angles
     /// </summary>
-    public struct EulerAngles : IEquatable<EulerAngles>
+    public readonly struct EulerAngles : IEquatable<EulerAngles>
     {
         /// <summary>
         /// Alpha (or phi) is the rotation around the z axis
@@ -35,9 +35,9 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="gamma">The gamma angle is the rotation around the Z axis</param>
         public EulerAngles(Angle alpha, Angle beta, Angle gamma)
         {
-            this.Alpha = alpha;
-            this.Beta = beta;
-            this.Gamma = gamma;
+            Alpha = alpha;
+            Beta = beta;
+            Gamma = gamma;
         }
 
         /// <summary>
@@ -69,7 +69,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsEmpty()
         {
-            return double.IsNaN(this.Alpha.Radians) && double.IsNaN(this.Beta.Radians) && double.IsNaN(this.Gamma.Radians);
+            return double.IsNaN(Alpha.Radians)
+                   && double.IsNaN(Beta.Radians)
+                   && double.IsNaN(Gamma.Radians);
         }
 
         /// <summary>
@@ -86,9 +88,9 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return this.Alpha.Equals(other.Alpha, tolerance) &&
-                   this.Beta.Equals(other.Beta, tolerance) &&
-                   this.Gamma.Equals(other.Gamma, tolerance);
+            return Alpha.Equals(other.Alpha, tolerance)
+                   && Beta.Equals(other.Beta, tolerance)
+                   && Gamma.Equals(other.Gamma, tolerance);
         }
 
         /// <summary>
@@ -100,24 +102,26 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(EulerAngles other, Angle tolerance)
         {
-            return this.Alpha.Equals(other.Alpha, tolerance) &&
-                   this.Beta.Equals(other.Beta, tolerance) &&
-                   this.Gamma.Equals(other.Gamma, tolerance);
+            return Alpha.Equals(other.Alpha, tolerance)
+                   && Beta.Equals(other.Beta, tolerance)
+                   && Gamma.Equals(other.Gamma, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
         public bool Equals(EulerAngles other)
         {
-            return this.Alpha.Equals(other.Alpha) && this.Beta.Equals(other.Beta) && this.Gamma.Equals(other.Gamma);
+            return Alpha.Equals(other.Alpha)
+                   && Beta.Equals(other.Beta)
+                   && Gamma.Equals(other.Gamma);
         }
 
         /// <inheritdoc/>
         [Pure]
-        public override bool Equals(object obj) => obj is EulerAngles angles && this.Equals(angles);
+        public override bool Equals(object obj) => obj is EulerAngles angles && Equals(angles);
 
         /// <inheritdoc/>
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.Alpha, this.Beta, this.Gamma);
+        public override int GetHashCode() => HashCode.Combine(Alpha, Beta, Gamma);
     }
 }

--- a/src/Spatial/Euclidean/EulerAngles.cs
+++ b/src/Spatial/Euclidean/EulerAngles.cs
@@ -9,7 +9,7 @@ namespace MathNet.Spatial.Euclidean
     /// A means of representing spatial orientation of any reference frame.
     /// More information can be found https://en.wikipedia.org/wiki/Euler_angles
     /// </summary>
-    public readonly struct EulerAngles : IEquatable<EulerAngles>
+    public struct EulerAngles : IEquatable<EulerAngles>
     {
         /// <summary>
         /// Alpha (or phi) is the rotation around the z axis
@@ -35,9 +35,9 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="gamma">The gamma angle is the rotation around the Z axis</param>
         public EulerAngles(Angle alpha, Angle beta, Angle gamma)
         {
-            Alpha = alpha;
-            Beta = beta;
-            Gamma = gamma;
+            this.Alpha = alpha;
+            this.Beta = beta;
+            this.Gamma = gamma;
         }
 
         /// <summary>
@@ -69,9 +69,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsEmpty()
         {
-            return double.IsNaN(Alpha.Radians)
-                   && double.IsNaN(Beta.Radians)
-                   && double.IsNaN(Gamma.Radians);
+            return double.IsNaN(this.Alpha.Radians) && double.IsNaN(this.Beta.Radians) && double.IsNaN(this.Gamma.Radians);
         }
 
         /// <summary>
@@ -88,9 +86,9 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Alpha.Equals(other.Alpha, tolerance)
-                   && Beta.Equals(other.Beta, tolerance)
-                   && Gamma.Equals(other.Gamma, tolerance);
+            return this.Alpha.Equals(other.Alpha, tolerance) &&
+                   this.Beta.Equals(other.Beta, tolerance) &&
+                   this.Gamma.Equals(other.Gamma, tolerance);
         }
 
         /// <summary>
@@ -102,26 +100,24 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(EulerAngles other, Angle tolerance)
         {
-            return Alpha.Equals(other.Alpha, tolerance)
-                   && Beta.Equals(other.Beta, tolerance)
-                   && Gamma.Equals(other.Gamma, tolerance);
+            return this.Alpha.Equals(other.Alpha, tolerance) &&
+                   this.Beta.Equals(other.Beta, tolerance) &&
+                   this.Gamma.Equals(other.Gamma, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
         public bool Equals(EulerAngles other)
         {
-            return Alpha.Equals(other.Alpha)
-                   && Beta.Equals(other.Beta)
-                   && Gamma.Equals(other.Gamma);
+            return this.Alpha.Equals(other.Alpha) && this.Beta.Equals(other.Beta) && this.Gamma.Equals(other.Gamma);
         }
 
         /// <inheritdoc/>
         [Pure]
-        public override bool Equals(object obj) => obj is EulerAngles angles && Equals(angles);
+        public override bool Equals(object obj) => obj is EulerAngles angles && this.Equals(angles);
 
         /// <inheritdoc/>
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(Alpha, Beta, Gamma);
+        public override int GetHashCode() => HashCode.Combine(this.Alpha, this.Beta, this.Gamma);
     }
 }

--- a/src/Spatial/Euclidean/Line2D.cs
+++ b/src/Spatial/Euclidean/Line2D.cs
@@ -9,7 +9,7 @@ namespace MathNet.Spatial.Euclidean
     /// This structure represents a line between two points in 2-space.  It allows for operations such as
     /// computing the length, direction, projections to, comparisons, and shifting by a vector.
     /// </summary>
-    public readonly struct Line2D : IEquatable<Line2D>
+    public struct Line2D : IEquatable<Line2D>
     {
         /// <summary>
         /// The starting point of the line segment
@@ -34,21 +34,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("The Line2D starting and ending points cannot be identical");
             }
 
-            StartPoint = startPoint;
-            EndPoint = endPoint;
+            this.StartPoint = startPoint;
+            this.EndPoint = endPoint;
         }
 
         /// <summary>
         /// Gets the distance from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public double Length => StartPoint.DistanceTo(EndPoint);
+        public double Length => this.StartPoint.DistanceTo(this.EndPoint);
 
         /// <summary>
         /// Gets a normalized vector in the direction from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public Vector2D Direction => StartPoint.VectorTo(EndPoint).Normalize();
+        public Vector2D Direction => this.StartPoint.VectorTo(this.EndPoint).Normalize();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.
@@ -126,7 +126,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Line2D LineTo(Point2D p, bool mustStartBetweenAndEnd)
         {
-            return new Line2D(ClosestPointTo(p, mustStartBetweenAndEnd), p);
+            return new Line2D(this.ClosestPointTo(p, mustStartBetweenAndEnd), p);
         }
 
         /// <summary>
@@ -138,8 +138,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point2D ClosestPointTo(Point2D p, bool mustBeOnSegment)
         {
-            var v = StartPoint.VectorTo(p);
-            var dotProduct = v.DotProduct(Direction);
+            var v = this.StartPoint.VectorTo(p);
+            var dotProduct = v.DotProduct(this.Direction);
             if (mustBeOnSegment)
             {
                 if (dotProduct < 0)
@@ -147,15 +147,15 @@ namespace MathNet.Spatial.Euclidean
                     dotProduct = 0;
                 }
 
-                var l = Length;
+                var l = this.Length;
                 if (dotProduct > l)
                 {
                     dotProduct = l;
                 }
             }
 
-            var alongVector = dotProduct * Direction;
-            return StartPoint + alongVector;
+            var alongVector = dotProduct * this.Direction;
+            return this.StartPoint + alongVector;
         }
 
         /// <summary>
@@ -167,15 +167,15 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point2D? IntersectWith(Line2D other)
         {
-            if (IsParallelTo(other))
+            if (this.IsParallelTo(other))
             {
                 return null;
             }
 
             // http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
-            var p = StartPoint;
+            var p = this.StartPoint;
             var q = other.StartPoint;
-            var r = StartPoint.VectorTo(EndPoint);
+            var r = this.StartPoint.VectorTo(this.EndPoint);
             var s = other.StartPoint.VectorTo(other.EndPoint);
 
             var t = (q - p).CrossProduct(s) / r.CrossProduct(s);
@@ -193,15 +193,15 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point2D? IntersectWith(Line2D other, Angle tolerance)
         {
-            if (IsParallelTo(other, tolerance))
+            if (this.IsParallelTo(other, tolerance))
             {
                 return null;
             }
 
             // http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
-            var p = StartPoint;
+            var p = this.StartPoint;
             var q = other.StartPoint;
-            var r = StartPoint.VectorTo(EndPoint);
+            var r = this.StartPoint.VectorTo(this.EndPoint);
             var s = other.StartPoint.VectorTo(other.EndPoint);
 
             var t = (q - p).CrossProduct(s) / r.CrossProduct(s);
@@ -218,7 +218,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Line2D other)
         {
-            return Direction.IsParallelTo(other.Direction, Precision.DoublePrecision * 2);
+            return this.Direction.IsParallelTo(other.Direction, Precision.DoublePrecision * 2);
         }
 
         /// <summary>
@@ -230,21 +230,21 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Line2D other, Angle tolerance)
         {
-            return Direction.IsParallelTo(other.Direction, tolerance);
+            return this.Direction.IsParallelTo(other.Direction, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
         public override string ToString()
         {
-            return $"StartPoint: {StartPoint}, EndPoint: {EndPoint}";
+            return $"StartPoint: {this.StartPoint}, EndPoint: {this.EndPoint}";
         }
 
         /// <inheritdoc/>
         [Pure]
         public bool Equals(Line2D other)
         {
-            return StartPoint.Equals(other.StartPoint) && EndPoint.Equals(other.EndPoint);
+            return this.StartPoint.Equals(other.StartPoint) && this.EndPoint.Equals(other.EndPoint);
         }
 
         /// <inheritdoc />
@@ -256,7 +256,7 @@ namespace MathNet.Spatial.Euclidean
                 return false;
             }
 
-            return obj is Line2D d && Equals(d);
+            return obj is Line2D d && this.Equals(d);
         }
 
         /// <inheritdoc />
@@ -265,7 +265,7 @@ namespace MathNet.Spatial.Euclidean
         {
             unchecked
             {
-                return (StartPoint.GetHashCode() * 397) ^ EndPoint.GetHashCode();
+                return (this.StartPoint.GetHashCode() * 397) ^ this.EndPoint.GetHashCode();
             }
         }
     }

--- a/src/Spatial/Euclidean/Line2D.cs
+++ b/src/Spatial/Euclidean/Line2D.cs
@@ -9,7 +9,7 @@ namespace MathNet.Spatial.Euclidean
     /// This structure represents a line between two points in 2-space.  It allows for operations such as
     /// computing the length, direction, projections to, comparisons, and shifting by a vector.
     /// </summary>
-    public struct Line2D : IEquatable<Line2D>
+    public readonly struct Line2D : IEquatable<Line2D>
     {
         /// <summary>
         /// The starting point of the line segment
@@ -34,21 +34,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("The Line2D starting and ending points cannot be identical");
             }
 
-            this.StartPoint = startPoint;
-            this.EndPoint = endPoint;
+            StartPoint = startPoint;
+            EndPoint = endPoint;
         }
 
         /// <summary>
         /// Gets the distance from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public double Length => this.StartPoint.DistanceTo(this.EndPoint);
+        public double Length => StartPoint.DistanceTo(EndPoint);
 
         /// <summary>
         /// Gets a normalized vector in the direction from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public Vector2D Direction => this.StartPoint.VectorTo(this.EndPoint).Normalize();
+        public Vector2D Direction => StartPoint.VectorTo(EndPoint).Normalize();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.
@@ -126,7 +126,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Line2D LineTo(Point2D p, bool mustStartBetweenAndEnd)
         {
-            return new Line2D(this.ClosestPointTo(p, mustStartBetweenAndEnd), p);
+            return new Line2D(ClosestPointTo(p, mustStartBetweenAndEnd), p);
         }
 
         /// <summary>
@@ -138,8 +138,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point2D ClosestPointTo(Point2D p, bool mustBeOnSegment)
         {
-            var v = this.StartPoint.VectorTo(p);
-            var dotProduct = v.DotProduct(this.Direction);
+            var v = StartPoint.VectorTo(p);
+            var dotProduct = v.DotProduct(Direction);
             if (mustBeOnSegment)
             {
                 if (dotProduct < 0)
@@ -147,15 +147,15 @@ namespace MathNet.Spatial.Euclidean
                     dotProduct = 0;
                 }
 
-                var l = this.Length;
+                var l = Length;
                 if (dotProduct > l)
                 {
                     dotProduct = l;
                 }
             }
 
-            var alongVector = dotProduct * this.Direction;
-            return this.StartPoint + alongVector;
+            var alongVector = dotProduct * Direction;
+            return StartPoint + alongVector;
         }
 
         /// <summary>
@@ -167,15 +167,15 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point2D? IntersectWith(Line2D other)
         {
-            if (this.IsParallelTo(other))
+            if (IsParallelTo(other))
             {
                 return null;
             }
 
             // http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
-            var p = this.StartPoint;
+            var p = StartPoint;
             var q = other.StartPoint;
-            var r = this.StartPoint.VectorTo(this.EndPoint);
+            var r = StartPoint.VectorTo(EndPoint);
             var s = other.StartPoint.VectorTo(other.EndPoint);
 
             var t = (q - p).CrossProduct(s) / r.CrossProduct(s);
@@ -193,15 +193,15 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point2D? IntersectWith(Line2D other, Angle tolerance)
         {
-            if (this.IsParallelTo(other, tolerance))
+            if (IsParallelTo(other, tolerance))
             {
                 return null;
             }
 
             // http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
-            var p = this.StartPoint;
+            var p = StartPoint;
             var q = other.StartPoint;
-            var r = this.StartPoint.VectorTo(this.EndPoint);
+            var r = StartPoint.VectorTo(EndPoint);
             var s = other.StartPoint.VectorTo(other.EndPoint);
 
             var t = (q - p).CrossProduct(s) / r.CrossProduct(s);
@@ -218,7 +218,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Line2D other)
         {
-            return this.Direction.IsParallelTo(other.Direction, Precision.DoublePrecision * 2);
+            return Direction.IsParallelTo(other.Direction, Precision.DoublePrecision * 2);
         }
 
         /// <summary>
@@ -230,21 +230,21 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Line2D other, Angle tolerance)
         {
-            return this.Direction.IsParallelTo(other.Direction, tolerance);
+            return Direction.IsParallelTo(other.Direction, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
         public override string ToString()
         {
-            return $"StartPoint: {this.StartPoint}, EndPoint: {this.EndPoint}";
+            return $"StartPoint: {StartPoint}, EndPoint: {EndPoint}";
         }
 
         /// <inheritdoc/>
         [Pure]
         public bool Equals(Line2D other)
         {
-            return this.StartPoint.Equals(other.StartPoint) && this.EndPoint.Equals(other.EndPoint);
+            return StartPoint.Equals(other.StartPoint) && EndPoint.Equals(other.EndPoint);
         }
 
         /// <inheritdoc />
@@ -256,7 +256,7 @@ namespace MathNet.Spatial.Euclidean
                 return false;
             }
 
-            return obj is Line2D d && this.Equals(d);
+            return obj is Line2D d && Equals(d);
         }
 
         /// <inheritdoc />
@@ -265,7 +265,7 @@ namespace MathNet.Spatial.Euclidean
         {
             unchecked
             {
-                return (this.StartPoint.GetHashCode() * 397) ^ this.EndPoint.GetHashCode();
+                return (StartPoint.GetHashCode() * 397) ^ EndPoint.GetHashCode();
             }
         }
     }

--- a/src/Spatial/Euclidean/Line3D.cs
+++ b/src/Spatial/Euclidean/Line3D.cs
@@ -39,21 +39,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("StartPoint == EndPoint");
             }
 
-            this.StartPoint = startPoint;
-            this.EndPoint = endPoint;
+            StartPoint = startPoint;
+            EndPoint = endPoint;
         }
 
         /// <summary>
         /// Gets distance from <see cref="StartPoint"/> to <see cref="EndPoint"/>, the length of the line
         /// </summary>
         [Pure]
-        public double Length => this.StartPoint.DistanceTo(this.EndPoint);
+        public double Length => StartPoint.DistanceTo(EndPoint);
 
         /// <summary>
         /// Gets the direction from the <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public UnitVector3D Direction => this.StartPoint.VectorTo(this.EndPoint).Normalize();
+        public UnitVector3D Direction => StartPoint.VectorTo(EndPoint).Normalize();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.
@@ -98,7 +98,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Line3D LineTo(Point3D p, bool mustStartBetweenStartAndEnd)
         {
-            return new Line3D(this.ClosestPointTo(p, mustStartBetweenStartAndEnd), p);
+            return new Line3D(ClosestPointTo(p, mustStartBetweenStartAndEnd), p);
         }
 
         /// <summary>
@@ -110,8 +110,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D ClosestPointTo(Point3D p, bool mustBeOnSegment)
         {
-            var v = p - this.StartPoint;
-            var dotProduct = v.DotProduct(this.Direction);
+            var v = p - StartPoint;
+            var dotProduct = v.DotProduct(Direction);
             if (mustBeOnSegment)
             {
                 if (dotProduct < 0)
@@ -119,14 +119,14 @@ namespace MathNet.Spatial.Euclidean
                     dotProduct = 0;
                 }
 
-                if (dotProduct > this.Length)
+                if (dotProduct > Length)
                 {
-                    dotProduct = this.Length;
+                    dotProduct = Length;
                 }
             }
 
-            var alongVector = dotProduct * this.Direction;
-            return this.StartPoint + alongVector;
+            var alongVector = dotProduct * Direction;
+            return StartPoint + alongVector;
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Line3D other)
         {
-            return this.Direction.IsParallelTo(other.Direction, Precision.DoublePrecision * 2);
+            return Direction.IsParallelTo(other.Direction, Precision.DoublePrecision * 2);
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Line3D other, Angle angleTolerance)
         {
-            return this.Direction.IsParallelTo(other.Direction, angleTolerance);
+            return Direction.IsParallelTo(other.Direction, angleTolerance);
         }
 
         /// <summary>
@@ -186,14 +186,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Tuple<Point3D, Point3D> ClosestPointsBetween(Line3D other)
         {
-            if (this.IsParallelTo(other))
+            if (IsParallelTo(other))
             {
-                return Tuple.Create(this.StartPoint, other.ClosestPointTo(this.StartPoint, false));
+                return Tuple.Create(StartPoint, other.ClosestPointTo(StartPoint, false));
             }
 
             // http://geomalgorithms.com/a07-_distance.html
-            var point0 = this.StartPoint;
-            var u = this.Direction;
+            var point0 = StartPoint;
+            var u = Direction;
             var point1 = other.StartPoint;
             var v = other.Direction;
 
@@ -224,11 +224,11 @@ namespace MathNet.Spatial.Euclidean
             // algorithm where the endpoints are projected onto the opposite segment and the smallest distance is
             // taken.  Otherwise we must first check if the infinite length line solution is valid.
             // If the lines aren't parallel OR it doesn't have to be constrained to the segments
-            if (!this.IsParallelTo(other) || !mustBeOnSegments)
+            if (!IsParallelTo(other) || !mustBeOnSegments)
             {
                 // Compute the unbounded result, and if mustBeOnSegments is false we can directly return the results
                 // since this is the same as calling the other method.
-                var result = this.ClosestPointsBetween(other);
+                var result = ClosestPointsBetween(other);
                 if (!mustBeOnSegments)
                 {
                     return result;
@@ -237,8 +237,8 @@ namespace MathNet.Spatial.Euclidean
                 // A point that is known to be collinear with the line start and end points is on the segment if
                 // its distance to both endpoints is less than the segment length.  If both projected points lie
                 // within their segment, we can directly return the result.
-                if (result.Item1.DistanceTo(this.StartPoint) <= this.Length &&
-                    result.Item1.DistanceTo(this.EndPoint) <= this.Length &&
+                if (result.Item1.DistanceTo(StartPoint) <= Length &&
+                    result.Item1.DistanceTo(EndPoint) <= Length &&
                     result.Item2.DistanceTo(other.StartPoint) <= other.Length &&
                     result.Item2.DistanceTo(other.EndPoint) <= other.Length)
                 {
@@ -251,20 +251,20 @@ namespace MathNet.Spatial.Euclidean
             //// case we project each of the four endpoints onto the opposite segments and select the one with the
             //// smallest projected distance.
 
-            var checkPoint = other.ClosestPointTo(this.StartPoint, true);
-            var distance = checkPoint.DistanceTo(this.StartPoint);
-            var closestPair = Tuple.Create(this.StartPoint, checkPoint);
+            var checkPoint = other.ClosestPointTo(StartPoint, true);
+            var distance = checkPoint.DistanceTo(StartPoint);
+            var closestPair = Tuple.Create(StartPoint, checkPoint);
             var minDistance = distance;
 
-            checkPoint = other.ClosestPointTo(this.EndPoint, true);
-            distance = checkPoint.DistanceTo(this.EndPoint);
+            checkPoint = other.ClosestPointTo(EndPoint, true);
+            distance = checkPoint.DistanceTo(EndPoint);
             if (distance < minDistance)
             {
-                closestPair = Tuple.Create(this.EndPoint, checkPoint);
+                closestPair = Tuple.Create(EndPoint, checkPoint);
                 minDistance = distance;
             }
 
-            checkPoint = this.ClosestPointTo(other.StartPoint, true);
+            checkPoint = ClosestPointTo(other.StartPoint, true);
             distance = checkPoint.DistanceTo(other.StartPoint);
             if (distance < minDistance)
             {
@@ -272,7 +272,7 @@ namespace MathNet.Spatial.Euclidean
                 minDistance = distance;
             }
 
-            checkPoint = this.ClosestPointTo(other.EndPoint, true);
+            checkPoint = ClosestPointTo(other.EndPoint, true);
             distance = checkPoint.DistanceTo(other.EndPoint);
             if (distance < minDistance)
             {
@@ -286,7 +286,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Line3D other)
         {
-            return this.StartPoint.Equals(other.StartPoint) && this.EndPoint.Equals(other.EndPoint);
+            return StartPoint.Equals(other.StartPoint) && EndPoint.Equals(other.EndPoint);
         }
 
         /// <inheritdoc />
@@ -298,7 +298,7 @@ namespace MathNet.Spatial.Euclidean
                 return false;
             }
 
-            return obj is Line3D d && this.Equals(d);
+            return obj is Line3D d && Equals(d);
         }
 
         /// <inheritdoc />
@@ -307,8 +307,8 @@ namespace MathNet.Spatial.Euclidean
         {
             unchecked
             {
-                var hashCode = this.StartPoint.GetHashCode();
-                hashCode = (hashCode * 397) ^ this.EndPoint.GetHashCode();
+                var hashCode = StartPoint.GetHashCode();
+                hashCode = (hashCode * 397) ^ EndPoint.GetHashCode();
                 return hashCode;
             }
         }
@@ -317,7 +317,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public override string ToString()
         {
-            return $"StartPoint: {this.StartPoint}, EndPoint: {this.EndPoint}";
+            return $"StartPoint: {StartPoint}, EndPoint: {EndPoint}";
         }
 
         /// <inheritdoc />
@@ -339,8 +339,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteElement("StartPoint", this.StartPoint);
-            writer.WriteElement("EndPoint", this.EndPoint);
+            writer.WriteElement("StartPoint", StartPoint);
+            writer.WriteElement("EndPoint", EndPoint);
         }
     }
 }

--- a/src/Spatial/Euclidean/Line3D.cs
+++ b/src/Spatial/Euclidean/Line3D.cs
@@ -39,21 +39,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("StartPoint == EndPoint");
             }
 
-            StartPoint = startPoint;
-            EndPoint = endPoint;
+            this.StartPoint = startPoint;
+            this.EndPoint = endPoint;
         }
 
         /// <summary>
         /// Gets distance from <see cref="StartPoint"/> to <see cref="EndPoint"/>, the length of the line
         /// </summary>
         [Pure]
-        public double Length => StartPoint.DistanceTo(EndPoint);
+        public double Length => this.StartPoint.DistanceTo(this.EndPoint);
 
         /// <summary>
         /// Gets the direction from the <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public UnitVector3D Direction => StartPoint.VectorTo(EndPoint).Normalize();
+        public UnitVector3D Direction => this.StartPoint.VectorTo(this.EndPoint).Normalize();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.
@@ -98,7 +98,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Line3D LineTo(Point3D p, bool mustStartBetweenStartAndEnd)
         {
-            return new Line3D(ClosestPointTo(p, mustStartBetweenStartAndEnd), p);
+            return new Line3D(this.ClosestPointTo(p, mustStartBetweenStartAndEnd), p);
         }
 
         /// <summary>
@@ -110,8 +110,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D ClosestPointTo(Point3D p, bool mustBeOnSegment)
         {
-            var v = p - StartPoint;
-            var dotProduct = v.DotProduct(Direction);
+            var v = p - this.StartPoint;
+            var dotProduct = v.DotProduct(this.Direction);
             if (mustBeOnSegment)
             {
                 if (dotProduct < 0)
@@ -119,14 +119,14 @@ namespace MathNet.Spatial.Euclidean
                     dotProduct = 0;
                 }
 
-                if (dotProduct > Length)
+                if (dotProduct > this.Length)
                 {
-                    dotProduct = Length;
+                    dotProduct = this.Length;
                 }
             }
 
-            var alongVector = dotProduct * Direction;
-            return StartPoint + alongVector;
+            var alongVector = dotProduct * this.Direction;
+            return this.StartPoint + alongVector;
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Line3D other)
         {
-            return Direction.IsParallelTo(other.Direction, Precision.DoublePrecision * 2);
+            return this.Direction.IsParallelTo(other.Direction, Precision.DoublePrecision * 2);
         }
 
         /// <summary>
@@ -173,7 +173,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Line3D other, Angle angleTolerance)
         {
-            return Direction.IsParallelTo(other.Direction, angleTolerance);
+            return this.Direction.IsParallelTo(other.Direction, angleTolerance);
         }
 
         /// <summary>
@@ -186,14 +186,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Tuple<Point3D, Point3D> ClosestPointsBetween(Line3D other)
         {
-            if (IsParallelTo(other))
+            if (this.IsParallelTo(other))
             {
-                return Tuple.Create(StartPoint, other.ClosestPointTo(StartPoint, false));
+                return Tuple.Create(this.StartPoint, other.ClosestPointTo(this.StartPoint, false));
             }
 
             // http://geomalgorithms.com/a07-_distance.html
-            var point0 = StartPoint;
-            var u = Direction;
+            var point0 = this.StartPoint;
+            var u = this.Direction;
             var point1 = other.StartPoint;
             var v = other.Direction;
 
@@ -224,11 +224,11 @@ namespace MathNet.Spatial.Euclidean
             // algorithm where the endpoints are projected onto the opposite segment and the smallest distance is
             // taken.  Otherwise we must first check if the infinite length line solution is valid.
             // If the lines aren't parallel OR it doesn't have to be constrained to the segments
-            if (!IsParallelTo(other) || !mustBeOnSegments)
+            if (!this.IsParallelTo(other) || !mustBeOnSegments)
             {
                 // Compute the unbounded result, and if mustBeOnSegments is false we can directly return the results
                 // since this is the same as calling the other method.
-                var result = ClosestPointsBetween(other);
+                var result = this.ClosestPointsBetween(other);
                 if (!mustBeOnSegments)
                 {
                     return result;
@@ -237,8 +237,8 @@ namespace MathNet.Spatial.Euclidean
                 // A point that is known to be collinear with the line start and end points is on the segment if
                 // its distance to both endpoints is less than the segment length.  If both projected points lie
                 // within their segment, we can directly return the result.
-                if (result.Item1.DistanceTo(StartPoint) <= Length &&
-                    result.Item1.DistanceTo(EndPoint) <= Length &&
+                if (result.Item1.DistanceTo(this.StartPoint) <= this.Length &&
+                    result.Item1.DistanceTo(this.EndPoint) <= this.Length &&
                     result.Item2.DistanceTo(other.StartPoint) <= other.Length &&
                     result.Item2.DistanceTo(other.EndPoint) <= other.Length)
                 {
@@ -251,20 +251,20 @@ namespace MathNet.Spatial.Euclidean
             //// case we project each of the four endpoints onto the opposite segments and select the one with the
             //// smallest projected distance.
 
-            var checkPoint = other.ClosestPointTo(StartPoint, true);
-            var distance = checkPoint.DistanceTo(StartPoint);
-            var closestPair = Tuple.Create(StartPoint, checkPoint);
+            var checkPoint = other.ClosestPointTo(this.StartPoint, true);
+            var distance = checkPoint.DistanceTo(this.StartPoint);
+            var closestPair = Tuple.Create(this.StartPoint, checkPoint);
             var minDistance = distance;
 
-            checkPoint = other.ClosestPointTo(EndPoint, true);
-            distance = checkPoint.DistanceTo(EndPoint);
+            checkPoint = other.ClosestPointTo(this.EndPoint, true);
+            distance = checkPoint.DistanceTo(this.EndPoint);
             if (distance < minDistance)
             {
-                closestPair = Tuple.Create(EndPoint, checkPoint);
+                closestPair = Tuple.Create(this.EndPoint, checkPoint);
                 minDistance = distance;
             }
 
-            checkPoint = ClosestPointTo(other.StartPoint, true);
+            checkPoint = this.ClosestPointTo(other.StartPoint, true);
             distance = checkPoint.DistanceTo(other.StartPoint);
             if (distance < minDistance)
             {
@@ -272,7 +272,7 @@ namespace MathNet.Spatial.Euclidean
                 minDistance = distance;
             }
 
-            checkPoint = ClosestPointTo(other.EndPoint, true);
+            checkPoint = this.ClosestPointTo(other.EndPoint, true);
             distance = checkPoint.DistanceTo(other.EndPoint);
             if (distance < minDistance)
             {
@@ -286,7 +286,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Line3D other)
         {
-            return StartPoint.Equals(other.StartPoint) && EndPoint.Equals(other.EndPoint);
+            return this.StartPoint.Equals(other.StartPoint) && this.EndPoint.Equals(other.EndPoint);
         }
 
         /// <inheritdoc />
@@ -298,7 +298,7 @@ namespace MathNet.Spatial.Euclidean
                 return false;
             }
 
-            return obj is Line3D d && Equals(d);
+            return obj is Line3D d && this.Equals(d);
         }
 
         /// <inheritdoc />
@@ -307,8 +307,8 @@ namespace MathNet.Spatial.Euclidean
         {
             unchecked
             {
-                var hashCode = StartPoint.GetHashCode();
-                hashCode = (hashCode * 397) ^ EndPoint.GetHashCode();
+                var hashCode = this.StartPoint.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.EndPoint.GetHashCode();
                 return hashCode;
             }
         }
@@ -317,7 +317,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public override string ToString()
         {
-            return $"StartPoint: {StartPoint}, EndPoint: {EndPoint}";
+            return $"StartPoint: {this.StartPoint}, EndPoint: {this.EndPoint}";
         }
 
         /// <inheritdoc />
@@ -339,8 +339,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteElement("StartPoint", StartPoint);
-            writer.WriteElement("EndPoint", EndPoint);
+            writer.WriteElement("StartPoint", this.StartPoint);
+            writer.WriteElement("EndPoint", this.EndPoint);
         }
     }
 }

--- a/src/Spatial/Euclidean/LineSegment2D.cs
+++ b/src/Spatial/Euclidean/LineSegment2D.cs
@@ -9,7 +9,7 @@ namespace MathNet.Spatial.Euclidean
     /// This structure represents a line between two points in 2-space.  It allows for operations such as
     /// computing the length, direction, comparisons, and shifting by a vector.
     /// </summary>
-    public readonly struct LineSegment2D : IEquatable<LineSegment2D>
+    public struct LineSegment2D : IEquatable<LineSegment2D>
     {
         /// <summary>
         /// The starting point of the line segment
@@ -34,21 +34,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("The segment starting and ending points cannot be identical");
             }
 
-            StartPoint = startPoint;
-            EndPoint = endPoint;
+            this.StartPoint = startPoint;
+            this.EndPoint = endPoint;
         }
 
         /// <summary>
         /// Gets the distance from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public double Length => StartPoint.DistanceTo(EndPoint);
+        public double Length => this.StartPoint.DistanceTo(this.EndPoint);
 
         /// <summary>
         /// Gets a normalized vector in the direction from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public Vector2D Direction => StartPoint.VectorTo(EndPoint).Normalize();
+        public Vector2D Direction => this.StartPoint.VectorTo(this.EndPoint).Normalize();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.
@@ -91,8 +91,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new translated line segment</returns>
         public LineSegment2D TranslateBy(Vector2D vector)
         {
-            var startVector = StartPoint.ToVector2D().Add(vector);
-            var endVector = EndPoint.ToVector2D().Add(vector);
+            var startVector = this.StartPoint.ToVector2D().Add(vector);
+            var endVector = this.EndPoint.ToVector2D().Add(vector);
             return new LineSegment2D(new Point2D(startVector.X, startVector.Y), new Point2D(endVector.X, endVector.Y));
         }
 
@@ -104,7 +104,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public LineSegment2D LineTo(Point2D p)
         {
-            return new LineSegment2D(ClosestPointTo(p), p);
+            return new LineSegment2D(this.ClosestPointTo(p), p);
         }
 
         /// <summary>
@@ -115,22 +115,22 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point2D ClosestPointTo(Point2D p)
         {
-            var v = StartPoint.VectorTo(p);
-            var dotProduct = v.DotProduct(Direction);
+            var v = this.StartPoint.VectorTo(p);
+            var dotProduct = v.DotProduct(this.Direction);
 
             if (dotProduct < 0)
             {
                 dotProduct = 0;
             }
 
-            var l = Length;
+            var l = this.Length;
             if (dotProduct > l)
             {
                 dotProduct = l;
             }
 
-            var alongVector = dotProduct * Direction;
-            return StartPoint + alongVector;
+            var alongVector = dotProduct * this.Direction;
+            return this.StartPoint + alongVector;
         }
 
         /// <summary>
@@ -144,16 +144,16 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool TryIntersect(LineSegment2D other, out Point2D intersection, Angle tolerance)
         {
-            if (IsParallelTo(other, tolerance))
+            if (this.IsParallelTo(other, tolerance))
             {
                 intersection = default(Point2D);
                 return false;
             }
 
             // http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
-            var p = StartPoint;
+            var p = this.StartPoint;
             var q = other.StartPoint;
-            var r = StartPoint.VectorTo(EndPoint);
+            var r = this.StartPoint.VectorTo(this.EndPoint);
             var s = other.StartPoint.VectorTo(other.EndPoint);
 
             var t = (q - p).CrossProduct(s) / r.CrossProduct(s);
@@ -172,14 +172,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(LineSegment2D other, Angle tolerance)
         {
-            return Direction.IsParallelTo(other.Direction, tolerance);
+            return this.Direction.IsParallelTo(other.Direction, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
         public override string ToString()
         {
-            return $"StartPoint: {StartPoint}, EndPoint: {EndPoint}";
+            return $"StartPoint: {this.StartPoint}, EndPoint: {this.EndPoint}";
         }
 
         /// <summary>
@@ -191,19 +191,19 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(LineSegment2D other, double tolerance)
         {
-            return StartPoint.Equals(other.StartPoint, tolerance) && EndPoint.Equals(other.EndPoint, tolerance);
+            return this.StartPoint.Equals(other.StartPoint, tolerance) && this.EndPoint.Equals(other.EndPoint, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
-        public bool Equals(LineSegment2D l) => StartPoint.Equals(l.StartPoint) && EndPoint.Equals(l.EndPoint);
+        public bool Equals(LineSegment2D l) => this.StartPoint.Equals(l.StartPoint) && this.EndPoint.Equals(l.EndPoint);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is LineSegment2D l && Equals(l);
+        public override bool Equals(object obj) => obj is LineSegment2D l && this.Equals(l);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(StartPoint, EndPoint);
+        public override int GetHashCode() => HashCode.Combine(this.StartPoint, this.EndPoint);
     }
 }

--- a/src/Spatial/Euclidean/LineSegment2D.cs
+++ b/src/Spatial/Euclidean/LineSegment2D.cs
@@ -9,7 +9,7 @@ namespace MathNet.Spatial.Euclidean
     /// This structure represents a line between two points in 2-space.  It allows for operations such as
     /// computing the length, direction, comparisons, and shifting by a vector.
     /// </summary>
-    public struct LineSegment2D : IEquatable<LineSegment2D>
+    public readonly struct LineSegment2D : IEquatable<LineSegment2D>
     {
         /// <summary>
         /// The starting point of the line segment
@@ -34,21 +34,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("The segment starting and ending points cannot be identical");
             }
 
-            this.StartPoint = startPoint;
-            this.EndPoint = endPoint;
+            StartPoint = startPoint;
+            EndPoint = endPoint;
         }
 
         /// <summary>
         /// Gets the distance from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public double Length => this.StartPoint.DistanceTo(this.EndPoint);
+        public double Length => StartPoint.DistanceTo(EndPoint);
 
         /// <summary>
         /// Gets a normalized vector in the direction from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public Vector2D Direction => this.StartPoint.VectorTo(this.EndPoint).Normalize();
+        public Vector2D Direction => StartPoint.VectorTo(EndPoint).Normalize();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.
@@ -91,8 +91,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new translated line segment</returns>
         public LineSegment2D TranslateBy(Vector2D vector)
         {
-            var startVector = this.StartPoint.ToVector2D().Add(vector);
-            var endVector = this.EndPoint.ToVector2D().Add(vector);
+            var startVector = StartPoint.ToVector2D().Add(vector);
+            var endVector = EndPoint.ToVector2D().Add(vector);
             return new LineSegment2D(new Point2D(startVector.X, startVector.Y), new Point2D(endVector.X, endVector.Y));
         }
 
@@ -104,7 +104,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public LineSegment2D LineTo(Point2D p)
         {
-            return new LineSegment2D(this.ClosestPointTo(p), p);
+            return new LineSegment2D(ClosestPointTo(p), p);
         }
 
         /// <summary>
@@ -115,22 +115,22 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point2D ClosestPointTo(Point2D p)
         {
-            var v = this.StartPoint.VectorTo(p);
-            var dotProduct = v.DotProduct(this.Direction);
+            var v = StartPoint.VectorTo(p);
+            var dotProduct = v.DotProduct(Direction);
 
             if (dotProduct < 0)
             {
                 dotProduct = 0;
             }
 
-            var l = this.Length;
+            var l = Length;
             if (dotProduct > l)
             {
                 dotProduct = l;
             }
 
-            var alongVector = dotProduct * this.Direction;
-            return this.StartPoint + alongVector;
+            var alongVector = dotProduct * Direction;
+            return StartPoint + alongVector;
         }
 
         /// <summary>
@@ -144,16 +144,16 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool TryIntersect(LineSegment2D other, out Point2D intersection, Angle tolerance)
         {
-            if (this.IsParallelTo(other, tolerance))
+            if (IsParallelTo(other, tolerance))
             {
                 intersection = default(Point2D);
                 return false;
             }
 
             // http://stackoverflow.com/questions/563198/how-do-you-detect-where-two-line-segments-intersect
-            var p = this.StartPoint;
+            var p = StartPoint;
             var q = other.StartPoint;
-            var r = this.StartPoint.VectorTo(this.EndPoint);
+            var r = StartPoint.VectorTo(EndPoint);
             var s = other.StartPoint.VectorTo(other.EndPoint);
 
             var t = (q - p).CrossProduct(s) / r.CrossProduct(s);
@@ -172,14 +172,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(LineSegment2D other, Angle tolerance)
         {
-            return this.Direction.IsParallelTo(other.Direction, tolerance);
+            return Direction.IsParallelTo(other.Direction, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
         public override string ToString()
         {
-            return $"StartPoint: {this.StartPoint}, EndPoint: {this.EndPoint}";
+            return $"StartPoint: {StartPoint}, EndPoint: {EndPoint}";
         }
 
         /// <summary>
@@ -191,19 +191,19 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(LineSegment2D other, double tolerance)
         {
-            return this.StartPoint.Equals(other.StartPoint, tolerance) && this.EndPoint.Equals(other.EndPoint, tolerance);
+            return StartPoint.Equals(other.StartPoint, tolerance) && EndPoint.Equals(other.EndPoint, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
-        public bool Equals(LineSegment2D l) => this.StartPoint.Equals(l.StartPoint) && this.EndPoint.Equals(l.EndPoint);
+        public bool Equals(LineSegment2D l) => StartPoint.Equals(l.StartPoint) && EndPoint.Equals(l.EndPoint);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is LineSegment2D l && this.Equals(l);
+        public override bool Equals(object obj) => obj is LineSegment2D l && Equals(l);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.StartPoint, this.EndPoint);
+        public override int GetHashCode() => HashCode.Combine(StartPoint, EndPoint);
     }
 }

--- a/src/Spatial/Euclidean/LineSegment3D.cs
+++ b/src/Spatial/Euclidean/LineSegment3D.cs
@@ -9,7 +9,7 @@ namespace MathNet.Spatial.Euclidean
     /// This structure represents a line between two points in 3D-space.  It allows for operations such as
     /// computing the length, direction, comparisons, and shifting by a vector.
     /// </summary>
-    public struct LineSegment3D : IEquatable<LineSegment3D>
+    public readonly struct LineSegment3D : IEquatable<LineSegment3D>
     {
         /// <summary>
         /// The starting point of the line segment
@@ -34,21 +34,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("The segment starting and ending points cannot be identical");
             }
 
-            this.StartPoint = startPoint;
-            this.EndPoint = endPoint;
+            StartPoint = startPoint;
+            EndPoint = endPoint;
         }
 
         /// <summary>
         /// Gets the distance from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public double Length => this.StartPoint.DistanceTo(this.EndPoint);
+        public double Length => StartPoint.DistanceTo(EndPoint);
 
         /// <summary>
         /// Gets a normalized vector in the direction from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public UnitVector3D Direction => this.StartPoint.VectorTo(this.EndPoint).Normalize();
+        public UnitVector3D Direction => StartPoint.VectorTo(EndPoint).Normalize();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.
@@ -91,7 +91,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new translated line segment</returns>
         public LineSegment3D TranslateBy(Vector3D vector)
         {
-            return new LineSegment3D(this.StartPoint + vector, this.EndPoint + vector);
+            return new LineSegment3D(StartPoint + vector, EndPoint + vector);
         }
 
         /// <summary>
@@ -102,21 +102,21 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D ClosestPointTo(Point3D p)
         {
-            var v = this.StartPoint.VectorTo(p);
-            var dotProduct = v.DotProduct(this.Direction);
+            var v = StartPoint.VectorTo(p);
+            var dotProduct = v.DotProduct(Direction);
 
             if (dotProduct < 0)
             {
                 dotProduct = 0;
             }
 
-            if (dotProduct > this.Length)
+            if (dotProduct > Length)
             {
-                dotProduct = this.Length;
+                dotProduct = Length;
             }
 
-            var alongVector = dotProduct * this.Direction;
-            return this.StartPoint + alongVector;
+            var alongVector = dotProduct * Direction;
+            return StartPoint + alongVector;
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public LineSegment3D LineTo(Point3D p)
         {
-            return new LineSegment3D(this.ClosestPointTo(p), p);
+            return new LineSegment3D(ClosestPointTo(p), p);
         }
 
         /// <summary>
@@ -145,16 +145,16 @@ namespace MathNet.Spatial.Euclidean
             // algorithm where the endpoints are projected onto the opposite segment and the smallest distance is
             // taken.  Otherwise we must first check if the infinite length line solution is valid.
             // If the lines aren't parallel
-            if (!this.IsParallelTo(other, tolerance))
+            if (!IsParallelTo(other, tolerance))
             {
                 // Compute the unbounded result
-                var result = this.ClosestPointsBetweenLines(other, tolerance);
+                var result = ClosestPointsBetweenLines(other, tolerance);
 
                 // A point that is known to be collinear with the line start and end points is on the segment if
                 // its distance to both endpoints is less than the segment length.  If both projected points lie
                 // within their segment, we can directly return the result.
-                if (result.Item1.DistanceTo(this.StartPoint) <= this.Length &&
-                    result.Item1.DistanceTo(this.EndPoint) <= this.Length &&
+                if (result.Item1.DistanceTo(StartPoint) <= Length &&
+                    result.Item1.DistanceTo(EndPoint) <= Length &&
                     result.Item2.DistanceTo(other.StartPoint) <= other.Length &&
                     result.Item2.DistanceTo(other.EndPoint) <= other.Length)
                 {
@@ -168,20 +168,20 @@ namespace MathNet.Spatial.Euclidean
             //// case we project each of the four endpoints onto the opposite segments and select the one with the
             //// smallest projected distance.
 
-            var checkPoint = other.ClosestPointTo(this.StartPoint);
-            var distance = checkPoint.DistanceTo(this.StartPoint);
-            var closestPair = Tuple.Create(this.StartPoint, checkPoint);
+            var checkPoint = other.ClosestPointTo(StartPoint);
+            var distance = checkPoint.DistanceTo(StartPoint);
+            var closestPair = Tuple.Create(StartPoint, checkPoint);
             var minDistance = distance;
 
-            checkPoint = other.ClosestPointTo(this.EndPoint);
-            distance = checkPoint.DistanceTo(this.EndPoint);
+            checkPoint = other.ClosestPointTo(EndPoint);
+            distance = checkPoint.DistanceTo(EndPoint);
             if (distance < minDistance)
             {
-                closestPair = Tuple.Create(this.EndPoint, checkPoint);
+                closestPair = Tuple.Create(EndPoint, checkPoint);
                 minDistance = distance;
             }
 
-            checkPoint = this.ClosestPointTo(other.StartPoint);
+            checkPoint = ClosestPointTo(other.StartPoint);
             distance = checkPoint.DistanceTo(other.StartPoint);
             if (distance < minDistance)
             {
@@ -189,7 +189,7 @@ namespace MathNet.Spatial.Euclidean
                 minDistance = distance;
             }
 
-            checkPoint = this.ClosestPointTo(other.EndPoint);
+            checkPoint = ClosestPointTo(other.EndPoint);
             distance = checkPoint.DistanceTo(other.EndPoint);
             if (distance < minDistance)
             {
@@ -215,14 +215,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(LineSegment3D other, Angle tolerance)
         {
-            return this.Direction.IsParallelTo(other.Direction, tolerance);
+            return Direction.IsParallelTo(other.Direction, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
         public override string ToString()
         {
-            return $"StartPoint: {this.StartPoint}, EndPoint: {this.EndPoint}";
+            return $"StartPoint: {StartPoint}, EndPoint: {EndPoint}";
         }
 
         /// <summary>
@@ -234,20 +234,20 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(LineSegment3D other, double tolerance)
         {
-            return this.StartPoint.Equals(other.StartPoint, tolerance) && this.EndPoint.Equals(other.EndPoint, tolerance);
+            return StartPoint.Equals(other.StartPoint, tolerance) && EndPoint.Equals(other.EndPoint, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
-        public bool Equals(LineSegment3D l) => this.StartPoint.Equals(l.StartPoint) && this.EndPoint.Equals(l.EndPoint);
+        public bool Equals(LineSegment3D l) => StartPoint.Equals(l.StartPoint) && EndPoint.Equals(l.EndPoint);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is LineSegment3D l && this.Equals(l);
+        public override bool Equals(object obj) => obj is LineSegment3D l && Equals(l);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.StartPoint, this.EndPoint);
+        public override int GetHashCode() => HashCode.Combine(StartPoint, EndPoint);
 
         /// <summary>
         /// Extends the segment to a infinite line and finds the closest point on that line to the provided point.
@@ -257,8 +257,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         private Point3D ClosestLinePointTo(Point3D p)
         {
-            var alongVector = this.StartPoint.VectorTo(p).DotProduct(this.Direction) * this.Direction;
-            return this.StartPoint + alongVector;
+            var alongVector = StartPoint.VectorTo(p).DotProduct(Direction) * Direction;
+            return StartPoint + alongVector;
         }
 
         /// <summary>
@@ -272,14 +272,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         private Tuple<Point3D, Point3D> ClosestPointsBetweenLines(LineSegment3D other, Angle tolerance)
         {
-            if (this.IsParallelTo(other, tolerance))
+            if (IsParallelTo(other, tolerance))
             {
-                return Tuple.Create(this.StartPoint, other.ClosestLinePointTo(this.StartPoint));
+                return Tuple.Create(StartPoint, other.ClosestLinePointTo(StartPoint));
             }
 
             // http://geomalgorithms.com/a07-_distance.html
-            var point0 = this.StartPoint;
-            var u = this.Direction;
+            var point0 = StartPoint;
+            var u = Direction;
             var point1 = other.StartPoint;
             var v = other.Direction;
 

--- a/src/Spatial/Euclidean/LineSegment3D.cs
+++ b/src/Spatial/Euclidean/LineSegment3D.cs
@@ -9,7 +9,7 @@ namespace MathNet.Spatial.Euclidean
     /// This structure represents a line between two points in 3D-space.  It allows for operations such as
     /// computing the length, direction, comparisons, and shifting by a vector.
     /// </summary>
-    public readonly struct LineSegment3D : IEquatable<LineSegment3D>
+    public struct LineSegment3D : IEquatable<LineSegment3D>
     {
         /// <summary>
         /// The starting point of the line segment
@@ -34,21 +34,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("The segment starting and ending points cannot be identical");
             }
 
-            StartPoint = startPoint;
-            EndPoint = endPoint;
+            this.StartPoint = startPoint;
+            this.EndPoint = endPoint;
         }
 
         /// <summary>
         /// Gets the distance from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public double Length => StartPoint.DistanceTo(EndPoint);
+        public double Length => this.StartPoint.DistanceTo(this.EndPoint);
 
         /// <summary>
         /// Gets a normalized vector in the direction from <see cref="StartPoint"/> to <see cref="EndPoint"/>
         /// </summary>
         [Pure]
-        public UnitVector3D Direction => StartPoint.VectorTo(EndPoint).Normalize();
+        public UnitVector3D Direction => this.StartPoint.VectorTo(this.EndPoint).Normalize();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified lines is equal.
@@ -91,7 +91,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new translated line segment</returns>
         public LineSegment3D TranslateBy(Vector3D vector)
         {
-            return new LineSegment3D(StartPoint + vector, EndPoint + vector);
+            return new LineSegment3D(this.StartPoint + vector, this.EndPoint + vector);
         }
 
         /// <summary>
@@ -102,21 +102,21 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D ClosestPointTo(Point3D p)
         {
-            var v = StartPoint.VectorTo(p);
-            var dotProduct = v.DotProduct(Direction);
+            var v = this.StartPoint.VectorTo(p);
+            var dotProduct = v.DotProduct(this.Direction);
 
             if (dotProduct < 0)
             {
                 dotProduct = 0;
             }
 
-            if (dotProduct > Length)
+            if (dotProduct > this.Length)
             {
-                dotProduct = Length;
+                dotProduct = this.Length;
             }
 
-            var alongVector = dotProduct * Direction;
-            return StartPoint + alongVector;
+            var alongVector = dotProduct * this.Direction;
+            return this.StartPoint + alongVector;
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public LineSegment3D LineTo(Point3D p)
         {
-            return new LineSegment3D(ClosestPointTo(p), p);
+            return new LineSegment3D(this.ClosestPointTo(p), p);
         }
 
         /// <summary>
@@ -145,16 +145,16 @@ namespace MathNet.Spatial.Euclidean
             // algorithm where the endpoints are projected onto the opposite segment and the smallest distance is
             // taken.  Otherwise we must first check if the infinite length line solution is valid.
             // If the lines aren't parallel
-            if (!IsParallelTo(other, tolerance))
+            if (!this.IsParallelTo(other, tolerance))
             {
                 // Compute the unbounded result
-                var result = ClosestPointsBetweenLines(other, tolerance);
+                var result = this.ClosestPointsBetweenLines(other, tolerance);
 
                 // A point that is known to be collinear with the line start and end points is on the segment if
                 // its distance to both endpoints is less than the segment length.  If both projected points lie
                 // within their segment, we can directly return the result.
-                if (result.Item1.DistanceTo(StartPoint) <= Length &&
-                    result.Item1.DistanceTo(EndPoint) <= Length &&
+                if (result.Item1.DistanceTo(this.StartPoint) <= this.Length &&
+                    result.Item1.DistanceTo(this.EndPoint) <= this.Length &&
                     result.Item2.DistanceTo(other.StartPoint) <= other.Length &&
                     result.Item2.DistanceTo(other.EndPoint) <= other.Length)
                 {
@@ -168,20 +168,20 @@ namespace MathNet.Spatial.Euclidean
             //// case we project each of the four endpoints onto the opposite segments and select the one with the
             //// smallest projected distance.
 
-            var checkPoint = other.ClosestPointTo(StartPoint);
-            var distance = checkPoint.DistanceTo(StartPoint);
-            var closestPair = Tuple.Create(StartPoint, checkPoint);
+            var checkPoint = other.ClosestPointTo(this.StartPoint);
+            var distance = checkPoint.DistanceTo(this.StartPoint);
+            var closestPair = Tuple.Create(this.StartPoint, checkPoint);
             var minDistance = distance;
 
-            checkPoint = other.ClosestPointTo(EndPoint);
-            distance = checkPoint.DistanceTo(EndPoint);
+            checkPoint = other.ClosestPointTo(this.EndPoint);
+            distance = checkPoint.DistanceTo(this.EndPoint);
             if (distance < minDistance)
             {
-                closestPair = Tuple.Create(EndPoint, checkPoint);
+                closestPair = Tuple.Create(this.EndPoint, checkPoint);
                 minDistance = distance;
             }
 
-            checkPoint = ClosestPointTo(other.StartPoint);
+            checkPoint = this.ClosestPointTo(other.StartPoint);
             distance = checkPoint.DistanceTo(other.StartPoint);
             if (distance < minDistance)
             {
@@ -189,7 +189,7 @@ namespace MathNet.Spatial.Euclidean
                 minDistance = distance;
             }
 
-            checkPoint = ClosestPointTo(other.EndPoint);
+            checkPoint = this.ClosestPointTo(other.EndPoint);
             distance = checkPoint.DistanceTo(other.EndPoint);
             if (distance < minDistance)
             {
@@ -215,14 +215,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(LineSegment3D other, Angle tolerance)
         {
-            return Direction.IsParallelTo(other.Direction, tolerance);
+            return this.Direction.IsParallelTo(other.Direction, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
         public override string ToString()
         {
-            return $"StartPoint: {StartPoint}, EndPoint: {EndPoint}";
+            return $"StartPoint: {this.StartPoint}, EndPoint: {this.EndPoint}";
         }
 
         /// <summary>
@@ -234,20 +234,20 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(LineSegment3D other, double tolerance)
         {
-            return StartPoint.Equals(other.StartPoint, tolerance) && EndPoint.Equals(other.EndPoint, tolerance);
+            return this.StartPoint.Equals(other.StartPoint, tolerance) && this.EndPoint.Equals(other.EndPoint, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
-        public bool Equals(LineSegment3D l) => StartPoint.Equals(l.StartPoint) && EndPoint.Equals(l.EndPoint);
+        public bool Equals(LineSegment3D l) => this.StartPoint.Equals(l.StartPoint) && this.EndPoint.Equals(l.EndPoint);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is LineSegment3D l && Equals(l);
+        public override bool Equals(object obj) => obj is LineSegment3D l && this.Equals(l);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(StartPoint, EndPoint);
+        public override int GetHashCode() => HashCode.Combine(this.StartPoint, this.EndPoint);
 
         /// <summary>
         /// Extends the segment to a infinite line and finds the closest point on that line to the provided point.
@@ -257,8 +257,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         private Point3D ClosestLinePointTo(Point3D p)
         {
-            var alongVector = StartPoint.VectorTo(p).DotProduct(Direction) * Direction;
-            return StartPoint + alongVector;
+            var alongVector = this.StartPoint.VectorTo(p).DotProduct(this.Direction) * this.Direction;
+            return this.StartPoint + alongVector;
         }
 
         /// <summary>
@@ -272,14 +272,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         private Tuple<Point3D, Point3D> ClosestPointsBetweenLines(LineSegment3D other, Angle tolerance)
         {
-            if (IsParallelTo(other, tolerance))
+            if (this.IsParallelTo(other, tolerance))
             {
-                return Tuple.Create(StartPoint, other.ClosestLinePointTo(StartPoint));
+                return Tuple.Create(this.StartPoint, other.ClosestLinePointTo(this.StartPoint));
             }
 
             // http://geomalgorithms.com/a07-_distance.html
-            var point0 = StartPoint;
-            var u = Direction;
+            var point0 = this.StartPoint;
+            var u = this.Direction;
             var point1 = other.StartPoint;
             var v = other.Direction;
 

--- a/src/Spatial/Euclidean/Matrix3D.cs
+++ b/src/Spatial/Euclidean/Matrix3D.cs
@@ -6,7 +6,7 @@ using MathNet.Spatial.Units;
 namespace MathNet.Spatial.Euclidean
 {
     /// <summary>
-    /// Helper class for working with 3D matrixes
+    /// Helper class for working with 3D matrices
     /// </summary>
     public static class Matrix3D
     {

--- a/src/Spatial/Euclidean/Matrix3D.cs
+++ b/src/Spatial/Euclidean/Matrix3D.cs
@@ -6,7 +6,7 @@ using MathNet.Spatial.Units;
 namespace MathNet.Spatial.Euclidean
 {
     /// <summary>
-    /// Helper class for working with 3D matrices
+    /// Helper class for working with 3D matrixes
     /// </summary>
     public static class Matrix3D
     {

--- a/src/Spatial/Euclidean/Plane.cs
+++ b/src/Spatial/Euclidean/Plane.cs
@@ -48,8 +48,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="offset">The Plane's distance from the origin along its normal vector.</param>
         public Plane(UnitVector3D normal, double offset = 0)
         {
-            this.Normal = normal;
-            this.D = -offset;
+            Normal = normal;
+            D = -offset;
         }
 
         /// <summary>
@@ -77,22 +77,22 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Gets the <see cref="Normal"/> x component.
         /// </summary>
-        public double A => this.Normal.X;
+        public double A => Normal.X;
 
         /// <summary>
         /// Gets the <see cref="Normal"/> y component.
         /// </summary>
-        public double B => this.Normal.Y;
+        public double B => Normal.Y;
 
         /// <summary>
         /// Gets the <see cref="Normal"/> y component.
         /// </summary>
-        public double C => this.Normal.Z;
+        public double C => Normal.Z;
 
         /// <summary>
         /// Gets the point on the plane closest to origin.
         /// </summary>
-        public Point3D RootPoint => (-this.D * this.Normal).ToPoint3D();
+        public Point3D RootPoint => (-D * Normal).ToPoint3D();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified geometric planes is equal.
@@ -164,9 +164,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double SignedDistanceTo(Point3D point)
         {
-            var p = this.Project(point);
+            var p = Project(point);
             var v = p.VectorTo(point);
-            return v.DotProduct(this.Normal);
+            return v.DotProduct(Normal);
         }
 
         /// <summary>
@@ -178,12 +178,12 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double SignedDistanceTo(Plane other)
         {
-            if (!this.Normal.IsParallelTo(other.Normal, tolerance: 1E-15))
+            if (!Normal.IsParallelTo(other.Normal, tolerance: 1E-15))
             {
                 throw new ArgumentException("Planes are not parallel");
             }
 
-            return this.SignedDistanceTo(other.RootPoint);
+            return SignedDistanceTo(other.RootPoint);
         }
 
         /// <summary>
@@ -195,9 +195,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double SignedDistanceTo(Ray3D ray)
         {
-            if (Math.Abs(ray.Direction.DotProduct(this.Normal) - 0) < 1E-15)
+            if (Math.Abs(ray.Direction.DotProduct(Normal) - 0) < 1E-15)
             {
-                return this.SignedDistanceTo(ray.ThroughPoint);
+                return SignedDistanceTo(ray.ThroughPoint);
             }
 
             return 0;
@@ -211,7 +211,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double AbsoluteDistanceTo(Point3D point)
         {
-            return Math.Abs(this.SignedDistanceTo(point));
+            return Math.Abs(SignedDistanceTo(point));
         }
 
         /// <summary>
@@ -223,9 +223,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D Project(Point3D p, UnitVector3D? projectionDirection = null)
         {
-            var dotProduct = this.Normal.DotProduct(p.ToVector3D());
-            var projectiononNormal = projectionDirection == null ? this.Normal : projectionDirection.Value;
-            var projectionVector = (dotProduct + this.D) * projectiononNormal;
+            var dotProduct = Normal.DotProduct(p.ToVector3D());
+            var projectiononNormal = projectionDirection == null ? Normal : projectionDirection.Value;
+            var projectionVector = (dotProduct + D) * projectiononNormal;
             return p - projectionVector;
         }
 
@@ -236,8 +236,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A projected line</returns>
         public Line3D Project(Line3D line3DToProject)
         {
-            var projectedStartPoint = this.Project(line3DToProject.StartPoint);
-            var projectedEndPoint = this.Project(line3DToProject.EndPoint);
+            var projectedStartPoint = Project(line3DToProject.StartPoint);
+            var projectedEndPoint = Project(line3DToProject.EndPoint);
             return new Line3D(projectedStartPoint, projectedEndPoint);
         }
 
@@ -249,8 +249,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public LineSegment3D Project(LineSegment3D line3DToProject)
         {
-            var projectedStartPoint = this.Project(line3DToProject.StartPoint);
-            var projectedEndPoint = this.Project(line3DToProject.EndPoint);
+            var projectedStartPoint = Project(line3DToProject.StartPoint);
+            var projectedEndPoint = Project(line3DToProject.EndPoint);
             return new LineSegment3D(projectedStartPoint, projectedEndPoint);
         }
 
@@ -262,8 +262,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Ray3D Project(Ray3D rayToProject)
         {
-            var projectedThroughPoint = this.Project(rayToProject.ThroughPoint);
-            var projectedDirection = this.Project(rayToProject.Direction.ToVector3D());
+            var projectedThroughPoint = Project(rayToProject.ThroughPoint);
+            var projectedDirection = Project(rayToProject.Direction.ToVector3D());
             return new Ray3D(projectedThroughPoint, projectedDirection.Direction);
         }
 
@@ -275,8 +275,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Ray3D Project(Vector3D vector3DToProject)
         {
-            var projectedEndPoint = this.Project(vector3DToProject.ToPoint3D());
-            var projectedZero = this.Project(new Point3D(0, 0, 0));
+            var projectedEndPoint = Project(vector3DToProject.ToPoint3D());
+            var projectedZero = Project(new Point3D(0, 0, 0));
             return new Ray3D(projectedZero, projectedZero.VectorTo(projectedEndPoint).Normalize());
         }
 
@@ -288,7 +288,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Ray3D Project(UnitVector3D vector3DToProject)
         {
-            return this.Project(vector3DToProject.ToVector3D());
+            return Project(vector3DToProject.ToVector3D());
         }
 
         /// <summary>
@@ -302,7 +302,7 @@ namespace MathNet.Spatial.Euclidean
         public Ray3D IntersectionWith(Plane intersectingPlane, double tolerance = float.Epsilon)
         {
             var a = new DenseMatrix(2, 3);
-            a.SetRow(0, this.Normal.ToVector());
+            a.SetRow(0, Normal.ToVector());
             a.SetRow(1, intersectingPlane.Normal.ToVector());
             var svd = a.Svd(true);
             if (svd.S[1] < tolerance)
@@ -312,7 +312,7 @@ namespace MathNet.Spatial.Euclidean
 
             var y = new DenseMatrix(2, 1)
             {
-                [0, 0] = -1 * this.D,
+                [0, 0] = -1 * D,
                 [1, 0] = -1 * intersectingPlane.D
             };
 
@@ -331,10 +331,10 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>Intersection Point or null</returns>
         public Point3D? IntersectionWith(Line3D line, double tolerance = float.Epsilon)
         {
-            if (line.Direction.IsPerpendicularTo(this.Normal, tolerance))
+            if (line.Direction.IsPerpendicularTo(Normal, tolerance))
             {
                 // either parallel or lies in the plane
-                var projectedPoint = this.Project(line.StartPoint, line.Direction);
+                var projectedPoint = Project(line.StartPoint, line.Direction);
                 if (projectedPoint == line.StartPoint)
                 {
                     throw new InvalidOperationException("Line lies in the plane");
@@ -344,9 +344,9 @@ namespace MathNet.Spatial.Euclidean
                 return null;
             }
 
-            var d = this.SignedDistanceTo(line.StartPoint);
+            var d = SignedDistanceTo(line.StartPoint);
             var u = line.StartPoint.VectorTo(line.EndPoint);
-            var t = -1 * d / u.DotProduct(this.Normal);
+            var t = -1 * d / u.DotProduct(Normal);
             if (t > 1 || t < 0)
             {
                 // They are not intersected
@@ -366,10 +366,10 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D? IntersectionWith(LineSegment3D line, double tolerance = float.Epsilon)
         {
-            if (line.Direction.IsPerpendicularTo(this.Normal, tolerance))
+            if (line.Direction.IsPerpendicularTo(Normal, tolerance))
             {
                 // either parallel or lies in the plane
-                var projectedPoint = this.Project(line.StartPoint, line.Direction);
+                var projectedPoint = Project(line.StartPoint, line.Direction);
                 if (projectedPoint == line.StartPoint)
                 {
                     throw new InvalidOperationException("Line lies in the plane");
@@ -379,9 +379,9 @@ namespace MathNet.Spatial.Euclidean
                 return null;
             }
 
-            var d = this.SignedDistanceTo(line.StartPoint);
+            var d = SignedDistanceTo(line.StartPoint);
             var u = line.StartPoint.VectorTo(line.EndPoint);
-            var t = -1 * d / u.DotProduct(this.Normal);
+            var t = -1 * d / u.DotProduct(Normal);
             if (t > 1 || t < 0)
             {
                 // They are not intersected
@@ -400,13 +400,13 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D IntersectionWith(Ray3D ray, double tolerance = float.Epsilon)
         {
-            if (this.Normal.IsPerpendicularTo(ray.Direction, tolerance))
+            if (Normal.IsPerpendicularTo(ray.Direction, tolerance))
             {
                 throw new InvalidOperationException("Ray is parallel to the plane.");
             }
 
-            var d = this.SignedDistanceTo(ray.ThroughPoint);
-            var t = -1 * d / ray.Direction.DotProduct(this.Normal);
+            var d = SignedDistanceTo(ray.ThroughPoint);
+            var t = -1 * d / ray.Direction.DotProduct(Normal);
             return ray.ThroughPoint + (t * ray.Direction);
         }
 
@@ -418,9 +418,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D MirrorAbout(Point3D p)
         {
-            var p2 = this.Project(p);
-            var d = this.SignedDistanceTo(p);
-            return p2 - (1 * d * this.Normal);
+            var p2 = Project(p);
+            var d = SignedDistanceTo(p);
+            return p2 - (1 * d * Normal);
         }
 
         /// <summary>
@@ -432,9 +432,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Plane Rotate(UnitVector3D aboutVector, Angle angle)
         {
-            var rootPoint = this.RootPoint;
+            var rootPoint = RootPoint;
             var rotatedPoint = rootPoint.Rotate(aboutVector, angle);
-            var rotatedPlaneVector = this.Normal.Rotate(aboutVector, angle);
+            var rotatedPlaneVector = Normal.Rotate(aboutVector, angle);
             return new Plane(rotatedPlaneVector, rotatedPoint);
         }
 
@@ -452,26 +452,26 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.D - this.D) < tolerance && this.Normal.Equals(other.Normal, tolerance);
+            return Math.Abs(other.D - D) < tolerance && Normal.Equals(other.Normal, tolerance);
         }
 
         /// <inheritdoc />
         [Pure]
-        public bool Equals(Plane p) => this.D.Equals(p.D) && this.Normal.Equals(p.Normal);
+        public bool Equals(Plane p) => D.Equals(p.D) && Normal.Equals(p.Normal);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Plane p && this.Equals(p);
+        public override bool Equals(object obj) => obj is Plane p && Equals(p);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.Normal, this.D);
+        public override int GetHashCode() => HashCode.Combine(Normal, D);
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return $"A:{Math.Round(this.A, 4)} B:{Math.Round(this.B, 4)} C:{Math.Round(this.C, 4)} D:{Math.Round(this.D, 4)}";
+            return $"A:{Math.Round(A, 4)} B:{Math.Round(B, 4)} C:{Math.Round(C, 4)} D:{Math.Round(D, 4)}";
         }
 
         /// <inheritdoc />
@@ -493,8 +493,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc/>
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteElement("RootPoint", this.RootPoint);
-            writer.WriteElement("Normal", this.Normal);
+            writer.WriteElement("RootPoint", RootPoint);
+            writer.WriteElement("Normal", Normal);
         }
     }
 }

--- a/src/Spatial/Euclidean/Plane.cs
+++ b/src/Spatial/Euclidean/Plane.cs
@@ -48,8 +48,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="offset">The Plane's distance from the origin along its normal vector.</param>
         public Plane(UnitVector3D normal, double offset = 0)
         {
-            Normal = normal;
-            D = -offset;
+            this.Normal = normal;
+            this.D = -offset;
         }
 
         /// <summary>
@@ -77,22 +77,22 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Gets the <see cref="Normal"/> x component.
         /// </summary>
-        public double A => Normal.X;
+        public double A => this.Normal.X;
 
         /// <summary>
         /// Gets the <see cref="Normal"/> y component.
         /// </summary>
-        public double B => Normal.Y;
+        public double B => this.Normal.Y;
 
         /// <summary>
         /// Gets the <see cref="Normal"/> y component.
         /// </summary>
-        public double C => Normal.Z;
+        public double C => this.Normal.Z;
 
         /// <summary>
         /// Gets the point on the plane closest to origin.
         /// </summary>
-        public Point3D RootPoint => (-D * Normal).ToPoint3D();
+        public Point3D RootPoint => (-this.D * this.Normal).ToPoint3D();
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified geometric planes is equal.
@@ -164,9 +164,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double SignedDistanceTo(Point3D point)
         {
-            var p = Project(point);
+            var p = this.Project(point);
             var v = p.VectorTo(point);
-            return v.DotProduct(Normal);
+            return v.DotProduct(this.Normal);
         }
 
         /// <summary>
@@ -178,12 +178,12 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double SignedDistanceTo(Plane other)
         {
-            if (!Normal.IsParallelTo(other.Normal, tolerance: 1E-15))
+            if (!this.Normal.IsParallelTo(other.Normal, tolerance: 1E-15))
             {
                 throw new ArgumentException("Planes are not parallel");
             }
 
-            return SignedDistanceTo(other.RootPoint);
+            return this.SignedDistanceTo(other.RootPoint);
         }
 
         /// <summary>
@@ -195,9 +195,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double SignedDistanceTo(Ray3D ray)
         {
-            if (Math.Abs(ray.Direction.DotProduct(Normal) - 0) < 1E-15)
+            if (Math.Abs(ray.Direction.DotProduct(this.Normal) - 0) < 1E-15)
             {
-                return SignedDistanceTo(ray.ThroughPoint);
+                return this.SignedDistanceTo(ray.ThroughPoint);
             }
 
             return 0;
@@ -211,7 +211,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double AbsoluteDistanceTo(Point3D point)
         {
-            return Math.Abs(SignedDistanceTo(point));
+            return Math.Abs(this.SignedDistanceTo(point));
         }
 
         /// <summary>
@@ -223,9 +223,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D Project(Point3D p, UnitVector3D? projectionDirection = null)
         {
-            var dotProduct = Normal.DotProduct(p.ToVector3D());
-            var projectiononNormal = projectionDirection == null ? Normal : projectionDirection.Value;
-            var projectionVector = (dotProduct + D) * projectiononNormal;
+            var dotProduct = this.Normal.DotProduct(p.ToVector3D());
+            var projectiononNormal = projectionDirection == null ? this.Normal : projectionDirection.Value;
+            var projectionVector = (dotProduct + this.D) * projectiononNormal;
             return p - projectionVector;
         }
 
@@ -236,8 +236,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A projected line</returns>
         public Line3D Project(Line3D line3DToProject)
         {
-            var projectedStartPoint = Project(line3DToProject.StartPoint);
-            var projectedEndPoint = Project(line3DToProject.EndPoint);
+            var projectedStartPoint = this.Project(line3DToProject.StartPoint);
+            var projectedEndPoint = this.Project(line3DToProject.EndPoint);
             return new Line3D(projectedStartPoint, projectedEndPoint);
         }
 
@@ -249,8 +249,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public LineSegment3D Project(LineSegment3D line3DToProject)
         {
-            var projectedStartPoint = Project(line3DToProject.StartPoint);
-            var projectedEndPoint = Project(line3DToProject.EndPoint);
+            var projectedStartPoint = this.Project(line3DToProject.StartPoint);
+            var projectedEndPoint = this.Project(line3DToProject.EndPoint);
             return new LineSegment3D(projectedStartPoint, projectedEndPoint);
         }
 
@@ -262,8 +262,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Ray3D Project(Ray3D rayToProject)
         {
-            var projectedThroughPoint = Project(rayToProject.ThroughPoint);
-            var projectedDirection = Project(rayToProject.Direction.ToVector3D());
+            var projectedThroughPoint = this.Project(rayToProject.ThroughPoint);
+            var projectedDirection = this.Project(rayToProject.Direction.ToVector3D());
             return new Ray3D(projectedThroughPoint, projectedDirection.Direction);
         }
 
@@ -275,8 +275,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Ray3D Project(Vector3D vector3DToProject)
         {
-            var projectedEndPoint = Project(vector3DToProject.ToPoint3D());
-            var projectedZero = Project(new Point3D(0, 0, 0));
+            var projectedEndPoint = this.Project(vector3DToProject.ToPoint3D());
+            var projectedZero = this.Project(new Point3D(0, 0, 0));
             return new Ray3D(projectedZero, projectedZero.VectorTo(projectedEndPoint).Normalize());
         }
 
@@ -288,7 +288,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Ray3D Project(UnitVector3D vector3DToProject)
         {
-            return Project(vector3DToProject.ToVector3D());
+            return this.Project(vector3DToProject.ToVector3D());
         }
 
         /// <summary>
@@ -302,7 +302,7 @@ namespace MathNet.Spatial.Euclidean
         public Ray3D IntersectionWith(Plane intersectingPlane, double tolerance = float.Epsilon)
         {
             var a = new DenseMatrix(2, 3);
-            a.SetRow(0, Normal.ToVector());
+            a.SetRow(0, this.Normal.ToVector());
             a.SetRow(1, intersectingPlane.Normal.ToVector());
             var svd = a.Svd(true);
             if (svd.S[1] < tolerance)
@@ -312,7 +312,7 @@ namespace MathNet.Spatial.Euclidean
 
             var y = new DenseMatrix(2, 1)
             {
-                [0, 0] = -1 * D,
+                [0, 0] = -1 * this.D,
                 [1, 0] = -1 * intersectingPlane.D
             };
 
@@ -331,10 +331,10 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>Intersection Point or null</returns>
         public Point3D? IntersectionWith(Line3D line, double tolerance = float.Epsilon)
         {
-            if (line.Direction.IsPerpendicularTo(Normal, tolerance))
+            if (line.Direction.IsPerpendicularTo(this.Normal, tolerance))
             {
                 // either parallel or lies in the plane
-                var projectedPoint = Project(line.StartPoint, line.Direction);
+                var projectedPoint = this.Project(line.StartPoint, line.Direction);
                 if (projectedPoint == line.StartPoint)
                 {
                     throw new InvalidOperationException("Line lies in the plane");
@@ -344,9 +344,9 @@ namespace MathNet.Spatial.Euclidean
                 return null;
             }
 
-            var d = SignedDistanceTo(line.StartPoint);
+            var d = this.SignedDistanceTo(line.StartPoint);
             var u = line.StartPoint.VectorTo(line.EndPoint);
-            var t = -1 * d / u.DotProduct(Normal);
+            var t = -1 * d / u.DotProduct(this.Normal);
             if (t > 1 || t < 0)
             {
                 // They are not intersected
@@ -366,10 +366,10 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D? IntersectionWith(LineSegment3D line, double tolerance = float.Epsilon)
         {
-            if (line.Direction.IsPerpendicularTo(Normal, tolerance))
+            if (line.Direction.IsPerpendicularTo(this.Normal, tolerance))
             {
                 // either parallel or lies in the plane
-                var projectedPoint = Project(line.StartPoint, line.Direction);
+                var projectedPoint = this.Project(line.StartPoint, line.Direction);
                 if (projectedPoint == line.StartPoint)
                 {
                     throw new InvalidOperationException("Line lies in the plane");
@@ -379,9 +379,9 @@ namespace MathNet.Spatial.Euclidean
                 return null;
             }
 
-            var d = SignedDistanceTo(line.StartPoint);
+            var d = this.SignedDistanceTo(line.StartPoint);
             var u = line.StartPoint.VectorTo(line.EndPoint);
-            var t = -1 * d / u.DotProduct(Normal);
+            var t = -1 * d / u.DotProduct(this.Normal);
             if (t > 1 || t < 0)
             {
                 // They are not intersected
@@ -400,13 +400,13 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D IntersectionWith(Ray3D ray, double tolerance = float.Epsilon)
         {
-            if (Normal.IsPerpendicularTo(ray.Direction, tolerance))
+            if (this.Normal.IsPerpendicularTo(ray.Direction, tolerance))
             {
                 throw new InvalidOperationException("Ray is parallel to the plane.");
             }
 
-            var d = SignedDistanceTo(ray.ThroughPoint);
-            var t = -1 * d / ray.Direction.DotProduct(Normal);
+            var d = this.SignedDistanceTo(ray.ThroughPoint);
+            var t = -1 * d / ray.Direction.DotProduct(this.Normal);
             return ray.ThroughPoint + (t * ray.Direction);
         }
 
@@ -418,9 +418,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D MirrorAbout(Point3D p)
         {
-            var p2 = Project(p);
-            var d = SignedDistanceTo(p);
-            return p2 - (1 * d * Normal);
+            var p2 = this.Project(p);
+            var d = this.SignedDistanceTo(p);
+            return p2 - (1 * d * this.Normal);
         }
 
         /// <summary>
@@ -432,9 +432,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Plane Rotate(UnitVector3D aboutVector, Angle angle)
         {
-            var rootPoint = RootPoint;
+            var rootPoint = this.RootPoint;
             var rotatedPoint = rootPoint.Rotate(aboutVector, angle);
-            var rotatedPlaneVector = Normal.Rotate(aboutVector, angle);
+            var rotatedPlaneVector = this.Normal.Rotate(aboutVector, angle);
             return new Plane(rotatedPlaneVector, rotatedPoint);
         }
 
@@ -452,26 +452,26 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.D - D) < tolerance && Normal.Equals(other.Normal, tolerance);
+            return Math.Abs(other.D - this.D) < tolerance && this.Normal.Equals(other.Normal, tolerance);
         }
 
         /// <inheritdoc />
         [Pure]
-        public bool Equals(Plane p) => D.Equals(p.D) && Normal.Equals(p.Normal);
+        public bool Equals(Plane p) => this.D.Equals(p.D) && this.Normal.Equals(p.Normal);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Plane p && Equals(p);
+        public override bool Equals(object obj) => obj is Plane p && this.Equals(p);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(Normal, D);
+        public override int GetHashCode() => HashCode.Combine(this.Normal, this.D);
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return $"A:{Math.Round(A, 4)} B:{Math.Round(B, 4)} C:{Math.Round(C, 4)} D:{Math.Round(D, 4)}";
+            return $"A:{Math.Round(this.A, 4)} B:{Math.Round(this.B, 4)} C:{Math.Round(this.C, 4)} D:{Math.Round(this.D, 4)}";
         }
 
         /// <inheritdoc />
@@ -493,8 +493,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc/>
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteElement("RootPoint", RootPoint);
-            writer.WriteElement("Normal", Normal);
+            writer.WriteElement("RootPoint", this.RootPoint);
+            writer.WriteElement("Normal", this.Normal);
         }
     }
 }

--- a/src/Spatial/Euclidean/Point2D.cs
+++ b/src/Spatial/Euclidean/Point2D.cs
@@ -37,8 +37,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="y">The y coordinate</param>
         public Point2D(double x, double y)
         {
-            X = x;
-            Y = y;
+            this.X = x;
+            this.Y = y;
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new point</returns>
         public Point2D TransformBy(Matrix<double> m)
         {
-            return OfVector(m.Multiply(ToVector()));
+            return OfVector(m.Multiply(this.ToVector()));
         }
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DistanceTo(Point2D otherPoint)
         {
-            var vector = VectorTo(otherPoint);
+            var vector = this.VectorTo(otherPoint);
             return vector.Length;
         }
 
@@ -264,7 +264,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D ToVector2D()
         {
-            return new Vector2D(X, Y);
+            return new Vector2D(this.X, this.Y);
         }
 
         /// <summary>
@@ -274,14 +274,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { X, Y });
+            return Vector<double>.Build.Dense(new[] { this.X, this.Y });
         }
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return ToString("G15", CultureInfo.InvariantCulture);
+            return this.ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -292,7 +292,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public string ToString(IFormatProvider provider)
         {
-            return ToString("G15", provider);
+            return this.ToString("G15", provider);
         }
 
         /// <inheritdoc />
@@ -301,7 +301,7 @@ namespace MathNet.Spatial.Euclidean
         {
             var numberFormatInfo = provider != null ? NumberFormatInfo.GetInstance(provider) : CultureInfo.InvariantCulture.NumberFormat;
             var separator = numberFormatInfo.NumberDecimalSeparator == "," ? ";" : ",";
-            return $"({X.ToString(format, numberFormatInfo)}{separator}\u00A0{Y.ToString(format, numberFormatInfo)})";
+            return $"({this.X.ToString(format, numberFormatInfo)}{separator}\u00A0{this.Y.ToString(format, numberFormatInfo)})";
         }
 
         /// <summary>
@@ -318,21 +318,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - X) < tolerance &&
-                   Math.Abs(other.Y - Y) < tolerance;
+            return Math.Abs(other.X - this.X) < tolerance &&
+                   Math.Abs(other.Y - this.Y) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
-        public bool Equals(Point2D other) => X.Equals(other.X) && Y.Equals(other.Y);
+        public bool Equals(Point2D other) => this.X.Equals(other.X) && this.Y.Equals(other.Y);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Point2D p && Equals(p);
+        public override bool Equals(object obj) => obj is Point2D p && this.Equals(p);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(X, Y);
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema() => null;
@@ -361,8 +361,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteAttribute("X", X);
-            writer.WriteAttribute("Y", Y);
+            writer.WriteAttribute("X", this.X);
+            writer.WriteAttribute("Y", this.Y);
         }
     }
 }

--- a/src/Spatial/Euclidean/Point2D.cs
+++ b/src/Spatial/Euclidean/Point2D.cs
@@ -37,8 +37,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="y">The y coordinate</param>
         public Point2D(double x, double y)
         {
-            this.X = x;
-            this.Y = y;
+            X = x;
+            Y = y;
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new point</returns>
         public Point2D TransformBy(Matrix<double> m)
         {
-            return OfVector(m.Multiply(this.ToVector()));
+            return OfVector(m.Multiply(ToVector()));
         }
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DistanceTo(Point2D otherPoint)
         {
-            var vector = this.VectorTo(otherPoint);
+            var vector = VectorTo(otherPoint);
             return vector.Length;
         }
 
@@ -264,7 +264,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D ToVector2D()
         {
-            return new Vector2D(this.X, this.Y);
+            return new Vector2D(X, Y);
         }
 
         /// <summary>
@@ -274,14 +274,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { this.X, this.Y });
+            return Vector<double>.Build.Dense(new[] { X, Y });
         }
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return this.ToString("G15", CultureInfo.InvariantCulture);
+            return ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -292,7 +292,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public string ToString(IFormatProvider provider)
         {
-            return this.ToString("G15", provider);
+            return ToString("G15", provider);
         }
 
         /// <inheritdoc />
@@ -301,7 +301,7 @@ namespace MathNet.Spatial.Euclidean
         {
             var numberFormatInfo = provider != null ? NumberFormatInfo.GetInstance(provider) : CultureInfo.InvariantCulture.NumberFormat;
             var separator = numberFormatInfo.NumberDecimalSeparator == "," ? ";" : ",";
-            return $"({this.X.ToString(format, numberFormatInfo)}{separator}\u00A0{this.Y.ToString(format, numberFormatInfo)})";
+            return $"({X.ToString(format, numberFormatInfo)}{separator}\u00A0{Y.ToString(format, numberFormatInfo)})";
         }
 
         /// <summary>
@@ -318,21 +318,21 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - this.X) < tolerance &&
-                   Math.Abs(other.Y - this.Y) < tolerance;
+            return Math.Abs(other.X - X) < tolerance &&
+                   Math.Abs(other.Y - Y) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
-        public bool Equals(Point2D other) => this.X.Equals(other.X) && this.Y.Equals(other.Y);
+        public bool Equals(Point2D other) => X.Equals(other.X) && Y.Equals(other.Y);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Point2D p && this.Equals(p);
+        public override bool Equals(object obj) => obj is Point2D p && Equals(p);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.X, this.Y);
+        public override int GetHashCode() => HashCode.Combine(X, Y);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema() => null;
@@ -361,8 +361,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteAttribute("X", this.X);
-            writer.WriteAttribute("Y", this.Y);
+            writer.WriteAttribute("X", X);
+            writer.WriteAttribute("Y", Y);
         }
     }
 }

--- a/src/Spatial/Euclidean/Point3D.cs
+++ b/src/Spatial/Euclidean/Point3D.cs
@@ -42,9 +42,9 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="z">The z component.</param>
         public Point3D(double x, double y, double z)
         {
-            this.X = x;
-            this.Y = y;
-            this.Z = z;
+            X = x;
+            Y = y;
+            Z = z;
         }
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D Rotate(Vector3D aboutVector, Angle angle)
         {
-            return this.Rotate(aboutVector.Normalize(), angle);
+            return Rotate(aboutVector.Normalize(), angle);
         }
 
         /// <summary>
@@ -329,7 +329,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DistanceTo(Point3D p)
         {
-            var vector = this.VectorTo(p);
+            var vector = VectorTo(p);
             return vector.Length;
         }
 
@@ -340,7 +340,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D ToVector3D()
         {
-            return new Vector3D(this.X, this.Y, this.Z);
+            return new Vector3D(X, Y, Z);
         }
 
         /// <summary>
@@ -362,7 +362,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D TransformBy(Matrix<double> m)
         {
-            return OfVector(m.Multiply(this.ToVector()));
+            return OfVector(m.Multiply(ToVector()));
         }
 
         /// <summary>
@@ -372,14 +372,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { this.X, this.Y, this.Z });
+            return Vector<double>.Build.Dense(new[] { X, Y, Z });
         }
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return this.ToString("G15", CultureInfo.InvariantCulture);
+            return ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -390,7 +390,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public string ToString(IFormatProvider provider)
         {
-            return this.ToString("G15", provider);
+            return ToString("G15", provider);
         }
 
         /// <inheritdoc />
@@ -399,7 +399,7 @@ namespace MathNet.Spatial.Euclidean
         {
             var numberFormatInfo = provider != null ? NumberFormatInfo.GetInstance(provider) : CultureInfo.InvariantCulture.NumberFormat;
             var separator = numberFormatInfo.NumberDecimalSeparator == "," ? ";" : ",";
-            return string.Format("({0}{1} {2}{1} {3})", this.X.ToString(format, numberFormatInfo), separator, this.Y.ToString(format, numberFormatInfo), this.Z.ToString(format, numberFormatInfo));
+            return string.Format("({0}{1} {2}{1} {3})", X.ToString(format, numberFormatInfo), separator, Y.ToString(format, numberFormatInfo), Z.ToString(format, numberFormatInfo));
         }
 
         /// <summary>
@@ -416,25 +416,25 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - this.X) < tolerance &&
-                   Math.Abs(other.Y - this.Y) < tolerance &&
-                   Math.Abs(other.Z - this.Z) < tolerance;
+            return Math.Abs(other.X - X) < tolerance &&
+                   Math.Abs(other.Y - Y) < tolerance &&
+                   Math.Abs(other.Z - Z) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(Point3D other)
         {
-            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
+            return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Point3D p && this.Equals(p);
+        public override bool Equals(object obj) => obj is Point3D p && Equals(p);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z);
+        public override int GetHashCode() => HashCode.Combine(X, Y, Z);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema() => null;
@@ -458,15 +458,15 @@ namespace MathNet.Spatial.Euclidean
                 return;
             }
 
-            throw new XmlException($"Could not read a {this.GetType()}");
+            throw new XmlException($"Could not read a {GetType()}");
         }
 
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteAttribute("X", this.X);
-            writer.WriteAttribute("Y", this.Y);
-            writer.WriteAttribute("Z", this.Z);
+            writer.WriteAttribute("X", X);
+            writer.WriteAttribute("Y", Y);
+            writer.WriteAttribute("Z", Z);
         }
     }
 }

--- a/src/Spatial/Euclidean/Point3D.cs
+++ b/src/Spatial/Euclidean/Point3D.cs
@@ -42,9 +42,9 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="z">The z component.</param>
         public Point3D(double x, double y, double z)
         {
-            X = x;
-            Y = y;
-            Z = z;
+            this.X = x;
+            this.Y = y;
+            this.Z = z;
         }
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D Rotate(Vector3D aboutVector, Angle angle)
         {
-            return Rotate(aboutVector.Normalize(), angle);
+            return this.Rotate(aboutVector.Normalize(), angle);
         }
 
         /// <summary>
@@ -329,7 +329,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DistanceTo(Point3D p)
         {
-            var vector = VectorTo(p);
+            var vector = this.VectorTo(p);
             return vector.Length;
         }
 
@@ -340,7 +340,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D ToVector3D()
         {
-            return new Vector3D(X, Y, Z);
+            return new Vector3D(this.X, this.Y, this.Z);
         }
 
         /// <summary>
@@ -362,7 +362,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D TransformBy(Matrix<double> m)
         {
-            return OfVector(m.Multiply(ToVector()));
+            return OfVector(m.Multiply(this.ToVector()));
         }
 
         /// <summary>
@@ -372,14 +372,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { X, Y, Z });
+            return Vector<double>.Build.Dense(new[] { this.X, this.Y, this.Z });
         }
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return ToString("G15", CultureInfo.InvariantCulture);
+            return this.ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -390,7 +390,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public string ToString(IFormatProvider provider)
         {
-            return ToString("G15", provider);
+            return this.ToString("G15", provider);
         }
 
         /// <inheritdoc />
@@ -399,7 +399,7 @@ namespace MathNet.Spatial.Euclidean
         {
             var numberFormatInfo = provider != null ? NumberFormatInfo.GetInstance(provider) : CultureInfo.InvariantCulture.NumberFormat;
             var separator = numberFormatInfo.NumberDecimalSeparator == "," ? ";" : ",";
-            return string.Format("({0}{1} {2}{1} {3})", X.ToString(format, numberFormatInfo), separator, Y.ToString(format, numberFormatInfo), Z.ToString(format, numberFormatInfo));
+            return string.Format("({0}{1} {2}{1} {3})", this.X.ToString(format, numberFormatInfo), separator, this.Y.ToString(format, numberFormatInfo), this.Z.ToString(format, numberFormatInfo));
         }
 
         /// <summary>
@@ -416,25 +416,25 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - X) < tolerance &&
-                   Math.Abs(other.Y - Y) < tolerance &&
-                   Math.Abs(other.Z - Z) < tolerance;
+            return Math.Abs(other.X - this.X) < tolerance &&
+                   Math.Abs(other.Y - this.Y) < tolerance &&
+                   Math.Abs(other.Z - this.Z) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(Point3D other)
         {
-            return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Point3D p && Equals(p);
+        public override bool Equals(object obj) => obj is Point3D p && this.Equals(p);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(X, Y, Z);
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema() => null;
@@ -458,15 +458,15 @@ namespace MathNet.Spatial.Euclidean
                 return;
             }
 
-            throw new XmlException($"Could not read a {GetType()}");
+            throw new XmlException($"Could not read a {this.GetType()}");
         }
 
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteAttribute("X", X);
-            writer.WriteAttribute("Y", Y);
-            writer.WriteAttribute("Z", Z);
+            writer.WriteAttribute("X", this.X);
+            writer.WriteAttribute("Y", this.Y);
+            writer.WriteAttribute("Z", this.Z);
         }
     }
 }

--- a/src/Spatial/Euclidean/PolyLine2D.cs
+++ b/src/Spatial/Euclidean/PolyLine2D.cs
@@ -15,7 +15,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Internal storage for the points
         /// </summary>
-        private readonly List<Point2D> _points;
+        private readonly List<Point2D> points;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolyLine2D"/> class.
@@ -24,18 +24,18 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="points">A list of points.</param>
         public PolyLine2D(IEnumerable<Point2D> points)
         {
-            _points = new List<Point2D>(points);
+            this.points = new List<Point2D>(points);
         }
 
         /// <summary>
         /// Gets the number of vertices in the polyline.
         /// </summary>
-        public int VertexCount => _points.Count;
+        public int VertexCount => this.points.Count;
 
         /// <summary>
         /// Gets the length of the polyline as the sum of the length of the individual segments
         /// </summary>
-        public double Length => GetPolyLineLength();
+        public double Length => this.GetPolyLineLength();
 
         /// <summary>
         /// Gets a list of vertices
@@ -44,7 +44,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                foreach (var point in _points)
+                foreach (var point in this.points)
                 {
                     yield return point;
                 }
@@ -112,7 +112,7 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("fraction must be between 0 and 1");
             }
 
-            return GetPointAtLengthFromStart(fraction * Length);
+            return this.GetPointAtLengthFromStart(fraction * this.Length);
         }
 
         /// <summary>
@@ -123,27 +123,27 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A point which is the specified distance along the line</returns>
         public Point2D GetPointAtLengthFromStart(double lengthFromStart)
         {
-            var length = Length;
+            var length = this.Length;
             if (lengthFromStart >= length)
             {
-                return _points.Last();
+                return this.points.Last();
             }
 
             if (lengthFromStart <= 0)
             {
-                return _points.First();
+                return this.points.First();
             }
 
             double cumulativeLength = 0;
             var i = 0;
             while (true)
             {
-                var nextLength = cumulativeLength + _points[i].DistanceTo(_points[i + 1]);
+                var nextLength = cumulativeLength + this.points[i].DistanceTo(this.points[i + 1]);
                 if (cumulativeLength <= lengthFromStart && nextLength > lengthFromStart)
                 {
                     var leftover = lengthFromStart - cumulativeLength;
-                    var direction = _points[i].VectorTo(_points[i + 1]).Normalize();
-                    return _points[i] + (direction * leftover);
+                    var direction = this.points[i].VectorTo(this.points[i + 1]).Normalize();
+                    return this.points[i] + (direction * leftover);
                 }
                 else
                 {
@@ -163,9 +163,9 @@ namespace MathNet.Spatial.Euclidean
             var minError = double.MaxValue;
             var closest = default(Point2D);
 
-            for (var i = 0; i < VertexCount - 1; i++)
+            for (var i = 0; i < this.VertexCount - 1; i++)
             {
-                var segment = new LineSegment2D(_points[i], _points[i + 1]);
+                var segment = new LineSegment2D(this.points[i], this.points[i + 1]);
                 var projected = segment.ClosestPointTo(p);
                 var error = p.DistanceTo(projected);
                 if (error < minError)
@@ -187,14 +187,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(PolyLine2D other, double tolerance)
         {
-            if (VertexCount != other?.VertexCount)
+            if (this.VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < _points.Count; i++)
+            for (var i = 0; i < this.points.Count; i++)
             {
-                if (!_points[i].Equals(other._points[i], tolerance))
+                if (!this.points[i].Equals(other.points[i], tolerance))
                 {
                     return false;
                 }
@@ -207,14 +207,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(PolyLine2D other)
         {
-            if (VertexCount != other?.VertexCount)
+            if (this.VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < _points.Count; i++)
+            for (var i = 0; i < this.points.Count; i++)
             {
-                if (!_points[i].Equals(other._points[i]))
+                if (!this.points[i].Equals(other.points[i]))
                 {
                     return false;
                 }
@@ -228,14 +228,14 @@ namespace MathNet.Spatial.Euclidean
         public override bool Equals(object obj)
         {
             return obj is PolyLine2D polyLine2D &&
-                   Equals(polyLine2D);
+                   this.Equals(polyLine2D);
         }
 
         /// <inheritdoc />
         [Pure]
         public override int GetHashCode()
         {
-            return HashCode.CombineMany(_points);
+            return HashCode.CombineMany(this.points);
         }
 
         /// <summary>
@@ -302,9 +302,9 @@ namespace MathNet.Spatial.Euclidean
         private double GetPolyLineLength()
         {
             double length = 0;
-            for (var i = 0; i < _points.Count - 1; ++i)
+            for (var i = 0; i < this.points.Count - 1; ++i)
             {
-                length += _points[i].DistanceTo(_points[i + 1]);
+                length += this.points[i].DistanceTo(this.points[i + 1]);
             }
 
             return length;

--- a/src/Spatial/Euclidean/PolyLine2D.cs
+++ b/src/Spatial/Euclidean/PolyLine2D.cs
@@ -15,7 +15,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Internal storage for the points
         /// </summary>
-        private readonly List<Point2D> points;
+        private readonly List<Point2D> _points;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolyLine2D"/> class.
@@ -24,18 +24,18 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="points">A list of points.</param>
         public PolyLine2D(IEnumerable<Point2D> points)
         {
-            this.points = new List<Point2D>(points);
+            _points = new List<Point2D>(points);
         }
 
         /// <summary>
         /// Gets the number of vertices in the polyline.
         /// </summary>
-        public int VertexCount => this.points.Count;
+        public int VertexCount => _points.Count;
 
         /// <summary>
         /// Gets the length of the polyline as the sum of the length of the individual segments
         /// </summary>
-        public double Length => this.GetPolyLineLength();
+        public double Length => GetPolyLineLength();
 
         /// <summary>
         /// Gets a list of vertices
@@ -44,7 +44,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                foreach (var point in this.points)
+                foreach (var point in _points)
                 {
                     yield return point;
                 }
@@ -112,7 +112,7 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("fraction must be between 0 and 1");
             }
 
-            return this.GetPointAtLengthFromStart(fraction * this.Length);
+            return GetPointAtLengthFromStart(fraction * Length);
         }
 
         /// <summary>
@@ -123,27 +123,27 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A point which is the specified distance along the line</returns>
         public Point2D GetPointAtLengthFromStart(double lengthFromStart)
         {
-            var length = this.Length;
+            var length = Length;
             if (lengthFromStart >= length)
             {
-                return this.points.Last();
+                return _points.Last();
             }
 
             if (lengthFromStart <= 0)
             {
-                return this.points.First();
+                return _points.First();
             }
 
             double cumulativeLength = 0;
             var i = 0;
             while (true)
             {
-                var nextLength = cumulativeLength + this.points[i].DistanceTo(this.points[i + 1]);
+                var nextLength = cumulativeLength + _points[i].DistanceTo(_points[i + 1]);
                 if (cumulativeLength <= lengthFromStart && nextLength > lengthFromStart)
                 {
                     var leftover = lengthFromStart - cumulativeLength;
-                    var direction = this.points[i].VectorTo(this.points[i + 1]).Normalize();
-                    return this.points[i] + (direction * leftover);
+                    var direction = _points[i].VectorTo(_points[i + 1]).Normalize();
+                    return _points[i] + (direction * leftover);
                 }
                 else
                 {
@@ -163,9 +163,9 @@ namespace MathNet.Spatial.Euclidean
             var minError = double.MaxValue;
             var closest = default(Point2D);
 
-            for (var i = 0; i < this.VertexCount - 1; i++)
+            for (var i = 0; i < VertexCount - 1; i++)
             {
-                var segment = new LineSegment2D(this.points[i], this.points[i + 1]);
+                var segment = new LineSegment2D(_points[i], _points[i + 1]);
                 var projected = segment.ClosestPointTo(p);
                 var error = p.DistanceTo(projected);
                 if (error < minError)
@@ -187,14 +187,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(PolyLine2D other, double tolerance)
         {
-            if (this.VertexCount != other?.VertexCount)
+            if (VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < this.points.Count; i++)
+            for (var i = 0; i < _points.Count; i++)
             {
-                if (!this.points[i].Equals(other.points[i], tolerance))
+                if (!_points[i].Equals(other._points[i], tolerance))
                 {
                     return false;
                 }
@@ -207,14 +207,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(PolyLine2D other)
         {
-            if (this.VertexCount != other?.VertexCount)
+            if (VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < this.points.Count; i++)
+            for (var i = 0; i < _points.Count; i++)
             {
-                if (!this.points[i].Equals(other.points[i]))
+                if (!_points[i].Equals(other._points[i]))
                 {
                     return false;
                 }
@@ -228,14 +228,14 @@ namespace MathNet.Spatial.Euclidean
         public override bool Equals(object obj)
         {
             return obj is PolyLine2D polyLine2D &&
-                   this.Equals(polyLine2D);
+                   Equals(polyLine2D);
         }
 
         /// <inheritdoc />
         [Pure]
         public override int GetHashCode()
         {
-            return HashCode.CombineMany(this.points);
+            return HashCode.CombineMany(_points);
         }
 
         /// <summary>
@@ -302,9 +302,9 @@ namespace MathNet.Spatial.Euclidean
         private double GetPolyLineLength()
         {
             double length = 0;
-            for (var i = 0; i < this.points.Count - 1; ++i)
+            for (var i = 0; i < _points.Count - 1; ++i)
             {
-                length += this.points[i].DistanceTo(this.points[i + 1]);
+                length += _points[i].DistanceTo(_points[i + 1]);
             }
 
             return length;

--- a/src/Spatial/Euclidean/PolyLine3D.cs
+++ b/src/Spatial/Euclidean/PolyLine3D.cs
@@ -14,7 +14,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// An internal list of points
         /// </summary>
-        private readonly List<Point3D> points;
+        private readonly List<Point3D> _points;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolyLine3D"/> class.
@@ -23,18 +23,18 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="points">A list of points.</param>
         public PolyLine3D(IEnumerable<Point3D> points)
         {
-            this.points = new List<Point3D>(points);
+            _points = new List<Point3D>(points);
         }
 
         /// <summary>
         /// Gets the number of vertices in the polyline.
         /// </summary>
-        public int VertexCount => this.points.Count;
+        public int VertexCount => _points.Count;
 
         /// <summary>
         /// Gets the length of the polyline, computed as the sum of the lengths of every segment
         /// </summary>
-        public double Length => this.GetPolyLineLength();
+        public double Length => GetPolyLineLength();
 
         /// <summary>
         /// Gets a list of vertices
@@ -43,7 +43,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                foreach (var point in this.points)
+                foreach (var point in _points)
                 {
                     yield return point;
                 }
@@ -85,7 +85,7 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("fraction must be between 0 and 1");
             }
 
-            return this.GetPointAtLengthFromStart(fraction * this.Length);
+            return GetPointAtLengthFromStart(fraction * Length);
         }
 
         /// <summary>
@@ -96,27 +96,27 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A point which is the specified distance along the line</returns>
         public Point3D GetPointAtLengthFromStart(double lengthFromStart)
         {
-            var length = this.Length;
+            var length = Length;
             if (lengthFromStart >= length)
             {
-                return this.points.Last();
+                return _points.Last();
             }
 
             if (lengthFromStart <= 0)
             {
-                return this.points.First();
+                return _points.First();
             }
 
             double cumulativeLength = 0;
             var i = 0;
             while (true)
             {
-                var nextLength = cumulativeLength + this.points[i].DistanceTo(this.points[i + 1]);
+                var nextLength = cumulativeLength + _points[i].DistanceTo(_points[i + 1]);
                 if (cumulativeLength <= lengthFromStart && nextLength > lengthFromStart)
                 {
                     var leftover = lengthFromStart - cumulativeLength;
-                    var direction = this.points[i].VectorTo(this.points[i + 1]).Normalize();
-                    return this.points[i] + (leftover * direction);
+                    var direction = _points[i].VectorTo(_points[i + 1]).Normalize();
+                    return _points[i] + (leftover * direction);
                 }
 
                 cumulativeLength = nextLength;
@@ -134,9 +134,9 @@ namespace MathNet.Spatial.Euclidean
             var minError = double.MaxValue;
             var closest = default(Point3D);
 
-            for (var i = 0; i < this.VertexCount - 1; i++)
+            for (var i = 0; i < VertexCount - 1; i++)
             {
-                var segment = new LineSegment3D(this.points[i], this.points[i + 1]);
+                var segment = new LineSegment3D(_points[i], _points[i + 1]);
                 var projected = segment.ClosestPointTo(p);
                 var error = p.DistanceTo(projected);
                 if (error < minError)
@@ -158,14 +158,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(PolyLine3D other, double tolerance)
         {
-            if (this.VertexCount != other?.VertexCount)
+            if (VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < this.points.Count; i++)
+            for (var i = 0; i < _points.Count; i++)
             {
-                if (!this.points[i].Equals(other.points[i], tolerance))
+                if (!_points[i].Equals(other._points[i], tolerance))
                 {
                     return false;
                 }
@@ -178,14 +178,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(PolyLine3D other)
         {
-            if (this.VertexCount != other?.VertexCount)
+            if (VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < this.points.Count; i++)
+            for (var i = 0; i < _points.Count; i++)
             {
-                if (!this.points[i].Equals(other.points[i]))
+                if (!_points[i].Equals(other._points[i]))
                 {
                     return false;
                 }
@@ -199,14 +199,14 @@ namespace MathNet.Spatial.Euclidean
         public override bool Equals(object obj)
         {
             return obj is PolyLine3D polyLine3D &&
-                   this.Equals(polyLine3D);
+                   Equals(polyLine3D);
         }
 
         /// <inheritdoc />
         [Pure]
         public override int GetHashCode()
         {
-            return HashCode.CombineMany(this.points);
+            return HashCode.CombineMany(_points);
         }
 
         /// <summary>
@@ -216,9 +216,9 @@ namespace MathNet.Spatial.Euclidean
         private double GetPolyLineLength()
         {
             double length = 0;
-            for (var i = 0; i < this.points.Count - 1; ++i)
+            for (var i = 0; i < _points.Count - 1; ++i)
             {
-                length += this.points[i].DistanceTo(this.points[i + 1]);
+                length += _points[i].DistanceTo(_points[i + 1]);
             }
 
             return length;

--- a/src/Spatial/Euclidean/PolyLine3D.cs
+++ b/src/Spatial/Euclidean/PolyLine3D.cs
@@ -14,7 +14,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// An internal list of points
         /// </summary>
-        private readonly List<Point3D> _points;
+        private readonly List<Point3D> points;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PolyLine3D"/> class.
@@ -23,18 +23,18 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="points">A list of points.</param>
         public PolyLine3D(IEnumerable<Point3D> points)
         {
-            _points = new List<Point3D>(points);
+            this.points = new List<Point3D>(points);
         }
 
         /// <summary>
         /// Gets the number of vertices in the polyline.
         /// </summary>
-        public int VertexCount => _points.Count;
+        public int VertexCount => this.points.Count;
 
         /// <summary>
         /// Gets the length of the polyline, computed as the sum of the lengths of every segment
         /// </summary>
-        public double Length => GetPolyLineLength();
+        public double Length => this.GetPolyLineLength();
 
         /// <summary>
         /// Gets a list of vertices
@@ -43,7 +43,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                foreach (var point in _points)
+                foreach (var point in this.points)
                 {
                     yield return point;
                 }
@@ -85,7 +85,7 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("fraction must be between 0 and 1");
             }
 
-            return GetPointAtLengthFromStart(fraction * Length);
+            return this.GetPointAtLengthFromStart(fraction * this.Length);
         }
 
         /// <summary>
@@ -96,27 +96,27 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A point which is the specified distance along the line</returns>
         public Point3D GetPointAtLengthFromStart(double lengthFromStart)
         {
-            var length = Length;
+            var length = this.Length;
             if (lengthFromStart >= length)
             {
-                return _points.Last();
+                return this.points.Last();
             }
 
             if (lengthFromStart <= 0)
             {
-                return _points.First();
+                return this.points.First();
             }
 
             double cumulativeLength = 0;
             var i = 0;
             while (true)
             {
-                var nextLength = cumulativeLength + _points[i].DistanceTo(_points[i + 1]);
+                var nextLength = cumulativeLength + this.points[i].DistanceTo(this.points[i + 1]);
                 if (cumulativeLength <= lengthFromStart && nextLength > lengthFromStart)
                 {
                     var leftover = lengthFromStart - cumulativeLength;
-                    var direction = _points[i].VectorTo(_points[i + 1]).Normalize();
-                    return _points[i] + (leftover * direction);
+                    var direction = this.points[i].VectorTo(this.points[i + 1]).Normalize();
+                    return this.points[i] + (leftover * direction);
                 }
 
                 cumulativeLength = nextLength;
@@ -134,9 +134,9 @@ namespace MathNet.Spatial.Euclidean
             var minError = double.MaxValue;
             var closest = default(Point3D);
 
-            for (var i = 0; i < VertexCount - 1; i++)
+            for (var i = 0; i < this.VertexCount - 1; i++)
             {
-                var segment = new LineSegment3D(_points[i], _points[i + 1]);
+                var segment = new LineSegment3D(this.points[i], this.points[i + 1]);
                 var projected = segment.ClosestPointTo(p);
                 var error = p.DistanceTo(projected);
                 if (error < minError)
@@ -158,14 +158,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(PolyLine3D other, double tolerance)
         {
-            if (VertexCount != other?.VertexCount)
+            if (this.VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < _points.Count; i++)
+            for (var i = 0; i < this.points.Count; i++)
             {
-                if (!_points[i].Equals(other._points[i], tolerance))
+                if (!this.points[i].Equals(other.points[i], tolerance))
                 {
                     return false;
                 }
@@ -178,14 +178,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(PolyLine3D other)
         {
-            if (VertexCount != other?.VertexCount)
+            if (this.VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < _points.Count; i++)
+            for (var i = 0; i < this.points.Count; i++)
             {
-                if (!_points[i].Equals(other._points[i]))
+                if (!this.points[i].Equals(other.points[i]))
                 {
                     return false;
                 }
@@ -199,14 +199,14 @@ namespace MathNet.Spatial.Euclidean
         public override bool Equals(object obj)
         {
             return obj is PolyLine3D polyLine3D &&
-                   Equals(polyLine3D);
+                   this.Equals(polyLine3D);
         }
 
         /// <inheritdoc />
         [Pure]
         public override int GetHashCode()
         {
-            return HashCode.CombineMany(_points);
+            return HashCode.CombineMany(this.points);
         }
 
         /// <summary>
@@ -216,9 +216,9 @@ namespace MathNet.Spatial.Euclidean
         private double GetPolyLineLength()
         {
             double length = 0;
-            for (var i = 0; i < _points.Count - 1; ++i)
+            for (var i = 0; i < this.points.Count - 1; ++i)
             {
-                length += _points[i].DistanceTo(_points[i + 1]);
+                length += this.points[i].DistanceTo(this.points[i + 1]);
             }
 
             return length;

--- a/src/Spatial/Euclidean/Polygon2D.cs
+++ b/src/Spatial/Euclidean/Polygon2D.cs
@@ -16,7 +16,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// A list of vertices.
         /// </summary>
-        private readonly ImmutableList<Point2D> _points;
+        private readonly ImmutableList<Point2D> points;
 
         /// <summary>
         /// A list of edges.  This list is lazy loaded on demand.
@@ -47,11 +47,11 @@ namespace MathNet.Spatial.Euclidean
 
             if (vertices[0].Equals(vertices[vertices.Length - 1]))
             {
-                this._points = ImmutableList.Create(vertices.Skip(1).ToArray());
+                this.points = ImmutableList.Create(vertices.Skip(1).ToArray());
             }
             else
             {
-                this._points = ImmutableList.Create(vertices);
+                this.points = ImmutableList.Create(vertices);
             }
         }
 
@@ -62,7 +62,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                foreach (var point in this._points)
+                foreach (var point in this.points)
                 {
                     yield return point;
                 }
@@ -76,12 +76,12 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                if (edges == null)
+                if (this.edges == null)
                 {
-                    PopulateEdgeList();
+                    this.PopulateEdgeList();
                 }
 
-                foreach (var edge in edges)
+                foreach (var edge in this.edges)
                 {
                     yield return edge;
                 }
@@ -91,7 +91,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Gets the number of vertices in the polygon.
         /// </summary>
-        public int VertexCount => this._points.Count;
+        public int VertexCount => this.points.Count;
 
         /// <summary>
         /// Returns a value that indicates whether each point in two specified polygons is equal.
@@ -126,7 +126,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>True if the vertices collide; otherwise false.</returns>
         public static bool ArePolygonVerticesColliding(Polygon2D a, Polygon2D b)
         {
-            return a._points.Any(b.EnclosesPoint) || b._points.Any(a.EnclosesPoint);
+            return a.points.Any(b.EnclosesPoint) || b.points.Any(a.EnclosesPoint);
         }
 
         /// <summary>
@@ -177,10 +177,10 @@ namespace MathNet.Spatial.Euclidean
         public bool EnclosesPoint(Point2D p)
         {
             var c = false;
-            for (int i = 0, j = this._points.Count - 1; i < this._points.Count; j = i++)
+            for (int i = 0, j = this.points.Count - 1; i < this.points.Count; j = i++)
             {
-                if (((this._points[i].Y > p.Y) != (this._points[j].Y > p.Y)) &&
-                    (p.X < ((this._points[j].X - this._points[i].X) * (p.Y - this._points[i].Y) / (this._points[j].Y - this._points[i].Y)) + this._points[i].X))
+                if (((this.points[i].Y > p.Y) != (this.points[j].Y > p.Y)) &&
+                    (p.X < ((this.points[j].X - this.points[i].X) * (p.Y - this.points[i].Y) / (this.points[j].Y - this.points[i].Y)) + this.points[i].X))
                 {
                     c = !c;
                 }
@@ -196,7 +196,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A polygon</returns>
         public Polygon2D ReduceComplexity(double singleStepTolerance)
         {
-            return new Polygon2D(PolyLine2D.ReduceComplexity(ToPolyLine2D().Vertices, singleStepTolerance).Vertices);
+            return new Polygon2D(PolyLine2D.ReduceComplexity(this.ToPolyLine2D().Vertices, singleStepTolerance).Vertices);
         }
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new polygon that has been rotated.</returns>
         public Polygon2D Rotate(Angle angle)
         {
-            var rotated = this._points.Select(t => Point2D.Origin + t.ToVector2D().Rotate(angle)).ToArray();
+            var rotated = this.points.Select(t => Point2D.Origin + t.ToVector2D().Rotate(angle)).ToArray();
             return new Polygon2D(rotated);
         }
 
@@ -217,7 +217,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new polygon that has been translated.</returns>
         public Polygon2D TranslateBy(Vector2D vector)
         {
-            var newPoints = from p in this._points select p + vector;
+            var newPoints = from p in this.points select p + vector;
             return new Polygon2D(newPoints);
         }
 
@@ -231,7 +231,7 @@ namespace MathNet.Spatial.Euclidean
         {
             // Shift to the origin
             var shiftVector = center.VectorTo(Point2D.Origin);
-            var tempPoly = TranslateBy(shiftVector);
+            var tempPoly = this.TranslateBy(shiftVector);
 
             // Rotate
             var rotatedPoly = tempPoly.Rotate(angle);
@@ -246,7 +246,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A polyline</returns>
         public PolyLine2D ToPolyLine2D()
         {
-            var points = _points.ToList();
+            var points = this.points.ToList();
             points.Add(points.First());
             return new PolyLine2D(points);
         }
@@ -260,14 +260,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Polygon2D other, double tolerance)
         {
-            if (VertexCount != other?.VertexCount)
+            if (this.VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < this._points.Count; i++)
+            for (var i = 0; i < this.points.Count; i++)
             {
-                if (!this._points[i].Equals(other._points[i], tolerance))
+                if (!this.points[i].Equals(other.points[i], tolerance))
                 {
                     return false;
                 }
@@ -280,14 +280,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Polygon2D other)
         {
-            if (VertexCount != other?.VertexCount)
+            if (this.VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < this._points.Count; i++)
+            for (var i = 0; i < this.points.Count; i++)
             {
-                if (!this._points[i].Equals(other._points[i]))
+                if (!this.points[i].Equals(other.points[i]))
                 {
                     return false;
                 }
@@ -305,14 +305,14 @@ namespace MathNet.Spatial.Euclidean
                 return false;
             }
 
-            return obj is Polygon2D d && Equals(d);
+            return obj is Polygon2D d && this.Equals(d);
         }
 
         /// <inheritdoc />
         [Pure]
         public override int GetHashCode()
         {
-            return HashCode.CombineMany(this._points);
+            return HashCode.CombineMany(this.points);
         }
 
         /// <summary>
@@ -320,15 +320,15 @@ namespace MathNet.Spatial.Euclidean
         /// </summary>
         private void PopulateEdgeList()
         {
-            var localedges = new List<LineSegment2D>(this._points.Count);
-            for (var i = 0; i < this._points.Count - 1; i++)
+            var localedges = new List<LineSegment2D>(this.points.Count);
+            for (var i = 0; i < this.points.Count - 1; i++)
             {
-                var edge = new LineSegment2D(this._points[i], this._points[i + 1]);
+                var edge = new LineSegment2D(this.points[i], this.points[i + 1]);
                 localedges.Add(edge);
             }
 
-            localedges.Add(new LineSegment2D(this._points[this._points.Count - 1], this._points[0])); // complete loop
-            edges = ImmutableList.Create(localedges);
+            localedges.Add(new LineSegment2D(this.points[this.points.Count - 1], this.points[0])); // complete loop
+            this.edges = ImmutableList.Create(localedges);
         }
     }
 }

--- a/src/Spatial/Euclidean/Polygon2D.cs
+++ b/src/Spatial/Euclidean/Polygon2D.cs
@@ -16,7 +16,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// A list of vertices.
         /// </summary>
-        private readonly ImmutableList<Point2D> points;
+        private readonly ImmutableList<Point2D> _points;
 
         /// <summary>
         /// A list of edges.  This list is lazy loaded on demand.
@@ -47,11 +47,11 @@ namespace MathNet.Spatial.Euclidean
 
             if (vertices[0].Equals(vertices[vertices.Length - 1]))
             {
-                this.points = ImmutableList.Create(vertices.Skip(1).ToArray());
+                this._points = ImmutableList.Create(vertices.Skip(1).ToArray());
             }
             else
             {
-                this.points = ImmutableList.Create(vertices);
+                this._points = ImmutableList.Create(vertices);
             }
         }
 
@@ -62,7 +62,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                foreach (var point in this.points)
+                foreach (var point in this._points)
                 {
                     yield return point;
                 }
@@ -76,12 +76,12 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                if (this.edges == null)
+                if (edges == null)
                 {
-                    this.PopulateEdgeList();
+                    PopulateEdgeList();
                 }
 
-                foreach (var edge in this.edges)
+                foreach (var edge in edges)
                 {
                     yield return edge;
                 }
@@ -91,7 +91,7 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Gets the number of vertices in the polygon.
         /// </summary>
-        public int VertexCount => this.points.Count;
+        public int VertexCount => this._points.Count;
 
         /// <summary>
         /// Returns a value that indicates whether each point in two specified polygons is equal.
@@ -126,7 +126,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>True if the vertices collide; otherwise false.</returns>
         public static bool ArePolygonVerticesColliding(Polygon2D a, Polygon2D b)
         {
-            return a.points.Any(b.EnclosesPoint) || b.points.Any(a.EnclosesPoint);
+            return a._points.Any(b.EnclosesPoint) || b._points.Any(a.EnclosesPoint);
         }
 
         /// <summary>
@@ -177,10 +177,10 @@ namespace MathNet.Spatial.Euclidean
         public bool EnclosesPoint(Point2D p)
         {
             var c = false;
-            for (int i = 0, j = this.points.Count - 1; i < this.points.Count; j = i++)
+            for (int i = 0, j = this._points.Count - 1; i < this._points.Count; j = i++)
             {
-                if (((this.points[i].Y > p.Y) != (this.points[j].Y > p.Y)) &&
-                    (p.X < ((this.points[j].X - this.points[i].X) * (p.Y - this.points[i].Y) / (this.points[j].Y - this.points[i].Y)) + this.points[i].X))
+                if (((this._points[i].Y > p.Y) != (this._points[j].Y > p.Y)) &&
+                    (p.X < ((this._points[j].X - this._points[i].X) * (p.Y - this._points[i].Y) / (this._points[j].Y - this._points[i].Y)) + this._points[i].X))
                 {
                     c = !c;
                 }
@@ -196,7 +196,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A polygon</returns>
         public Polygon2D ReduceComplexity(double singleStepTolerance)
         {
-            return new Polygon2D(PolyLine2D.ReduceComplexity(this.ToPolyLine2D().Vertices, singleStepTolerance).Vertices);
+            return new Polygon2D(PolyLine2D.ReduceComplexity(ToPolyLine2D().Vertices, singleStepTolerance).Vertices);
         }
 
         /// <summary>
@@ -206,7 +206,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new polygon that has been rotated.</returns>
         public Polygon2D Rotate(Angle angle)
         {
-            var rotated = this.points.Select(t => Point2D.Origin + t.ToVector2D().Rotate(angle)).ToArray();
+            var rotated = this._points.Select(t => Point2D.Origin + t.ToVector2D().Rotate(angle)).ToArray();
             return new Polygon2D(rotated);
         }
 
@@ -217,7 +217,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new polygon that has been translated.</returns>
         public Polygon2D TranslateBy(Vector2D vector)
         {
-            var newPoints = from p in this.points select p + vector;
+            var newPoints = from p in this._points select p + vector;
             return new Polygon2D(newPoints);
         }
 
@@ -231,7 +231,7 @@ namespace MathNet.Spatial.Euclidean
         {
             // Shift to the origin
             var shiftVector = center.VectorTo(Point2D.Origin);
-            var tempPoly = this.TranslateBy(shiftVector);
+            var tempPoly = TranslateBy(shiftVector);
 
             // Rotate
             var rotatedPoly = tempPoly.Rotate(angle);
@@ -246,7 +246,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A polyline</returns>
         public PolyLine2D ToPolyLine2D()
         {
-            var points = this.points.ToList();
+            var points = _points.ToList();
             points.Add(points.First());
             return new PolyLine2D(points);
         }
@@ -260,14 +260,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Polygon2D other, double tolerance)
         {
-            if (this.VertexCount != other?.VertexCount)
+            if (VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < this.points.Count; i++)
+            for (var i = 0; i < this._points.Count; i++)
             {
-                if (!this.points[i].Equals(other.points[i], tolerance))
+                if (!this._points[i].Equals(other._points[i], tolerance))
                 {
                     return false;
                 }
@@ -280,14 +280,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Polygon2D other)
         {
-            if (this.VertexCount != other?.VertexCount)
+            if (VertexCount != other?.VertexCount)
             {
                 return false;
             }
 
-            for (var i = 0; i < this.points.Count; i++)
+            for (var i = 0; i < this._points.Count; i++)
             {
-                if (!this.points[i].Equals(other.points[i]))
+                if (!this._points[i].Equals(other._points[i]))
                 {
                     return false;
                 }
@@ -305,14 +305,14 @@ namespace MathNet.Spatial.Euclidean
                 return false;
             }
 
-            return obj is Polygon2D d && this.Equals(d);
+            return obj is Polygon2D d && Equals(d);
         }
 
         /// <inheritdoc />
         [Pure]
         public override int GetHashCode()
         {
-            return HashCode.CombineMany(this.points);
+            return HashCode.CombineMany(this._points);
         }
 
         /// <summary>
@@ -320,15 +320,15 @@ namespace MathNet.Spatial.Euclidean
         /// </summary>
         private void PopulateEdgeList()
         {
-            var localedges = new List<LineSegment2D>(this.points.Count);
-            for (var i = 0; i < this.points.Count - 1; i++)
+            var localedges = new List<LineSegment2D>(this._points.Count);
+            for (var i = 0; i < this._points.Count - 1; i++)
             {
-                var edge = new LineSegment2D(this.points[i], this.points[i + 1]);
+                var edge = new LineSegment2D(this._points[i], this._points[i + 1]);
                 localedges.Add(edge);
             }
 
-            localedges.Add(new LineSegment2D(this.points[this.points.Count - 1], this.points[0])); // complete loop
-            this.edges = ImmutableList.Create(localedges);
+            localedges.Add(new LineSegment2D(this._points[this._points.Count - 1], this._points[0])); // complete loop
+            edges = ImmutableList.Create(localedges);
         }
     }
 }

--- a/src/Spatial/Euclidean/Quaternion.cs
+++ b/src/Spatial/Euclidean/Quaternion.cs
@@ -14,7 +14,7 @@ namespace MathNet.Spatial.Euclidean
     /// http://web.cs.iastate.edu/~cs577/handouts/quaternion.pdf
     /// http://www.lce.hut.fi/~ssarkka/pub/quat.pdf
     /// </remarks>
-    public readonly struct Quaternion : IEquatable<Quaternion>, IFormattable
+    public struct Quaternion : IEquatable<Quaternion>, IFormattable
     {
         /// <summary>
         /// Neutral element for multiplication
@@ -55,10 +55,10 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="imagZ">The Z-value of the vector component of the Quaternion</param>
         public Quaternion(double real, double imagX, double imagY, double imagZ)
         {
-            x = imagX;
-            y = imagY;
-            z = imagZ;
-            w = real;
+            this.x = imagX;
+            this.y = imagY;
+            this.z = imagZ;
+            this.w = real;
         }
 
         /// <summary>
@@ -74,39 +74,39 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Gets the real part of the quaternion.
         /// </summary>
-        public double Real => w;
+        public double Real => this.w;
 
         /// <summary>
         /// Gets the imaginary X part (coefficient of complex I) of the quaternion.
         /// </summary>
-        public double ImagX => x;
+        public double ImagX => this.x;
 
         /// <summary>
         /// Gets the imaginary Y part (coefficient of complex J) of the quaternion.
         /// </summary>
-        public double ImagY => y;
+        public double ImagY => this.y;
 
         /// <summary>
         /// Gets the imaginary Z part (coefficient of complex K) of the quaternion.
         /// </summary>
-        public double ImagZ => z;
+        public double ImagZ => this.z;
 
         /// <summary>
         /// Gets the sum of the squares of the four components.
         /// </summary>
-        public double NormSquared => ToNormSquared(Real, ImagX, ImagY, ImagZ);
+        public double NormSquared => ToNormSquared(this.Real, this.ImagX, this.ImagY, this.ImagZ);
 
         /// <summary>
         /// Gets the norm of the quaternion q: square root of the sum of the squares of the four components.
         /// </summary>
-        public double Norm => Math.Sqrt(NormSquared);
+        public double Norm => Math.Sqrt(this.NormSquared);
 
         /// <summary>
         /// Gets the argument phi = arg(q) of the quaternion q, such that q = r*(cos(phi) +
         /// u*sin(phi)) = r*exp(phi*u) where r is the absolute and u the unit vector of
         /// q.
         /// </summary>
-        public double Arg => Math.Acos(Real / Norm);
+        public double Arg => Math.Acos(this.Real / this.Norm);
 
         /// <summary>
         /// Gets a value indicating whether the quaternion q has length |q| = 1.
@@ -115,29 +115,29 @@ namespace MathNet.Spatial.Euclidean
         /// To normalize a quaternion to a length of 1, use the <see cref="Normalized"/> method.
         /// All unit quaternions form a 3-sphere.
         /// </remarks>
-        public bool IsUnitQuaternion => NormSquared.AlmostEqual(1);
+        public bool IsUnitQuaternion => this.NormSquared.AlmostEqual(1);
 
         /// <summary>
         /// Gets a new Quaternion q with the Scalar part only.
         /// If you need a Double, use the Real-Field instead.
         /// </summary>
-        public Quaternion Scalar => new Quaternion(w, 0, 0, 0);
+        public Quaternion Scalar => new Quaternion(this.w, 0, 0, 0);
 
         /// <summary>
         /// Gets a new Quaternion q with the Vector part only.
         /// </summary>
-        public Quaternion Vector => new Quaternion(0, x, y, z);
+        public Quaternion Vector => new Quaternion(0, this.x, this.y, this.z);
 
         /// <summary>
         /// Gets a new normalized Quaternion u with the Vector part only, such that ||u|| = 1.
         /// Q may then be represented as q = r*(cos(phi) + u*sin(phi)) = r*exp(phi*u) where r is the absolute and phi the argument of q.
         /// </summary>
-        public Quaternion NormalizedVector => ToUnitQuaternion(0, x, y, z);
+        public Quaternion NormalizedVector => ToUnitQuaternion(0, this.x, this.y, this.z);
 
         /// <summary>
         /// Gets a new normalized Quaternion q with the direction of this quaternion.
         /// </summary>
-        public Quaternion Normalized => this == Zero ? this : ToUnitQuaternion(w, x, y, z);
+        public Quaternion Normalized => this == Zero ? this : ToUnitQuaternion(this.w, this.x, this.y, this.z);
 
         /// <summary>
         /// Gets an inverted quaternion. Inversing Zero returns Zero
@@ -151,26 +151,26 @@ namespace MathNet.Spatial.Euclidean
                     return this;
                 }
 
-                var normSquared = NormSquared;
-                return new Quaternion(w / normSquared, -x / normSquared, -y / normSquared, -z / normSquared);
+                var normSquared = this.NormSquared;
+                return new Quaternion(this.w / normSquared, -this.x / normSquared, -this.y / normSquared, -this.z / normSquared);
             }
         }
 
         /// <summary>
         /// Gets a value indicating whether the quaternion is not a number
         /// </summary>
-        public bool IsNan => double.IsNaN(Real) ||
-                             double.IsNaN(ImagX) ||
-                             double.IsNaN(ImagY) ||
-                             double.IsNaN(ImagZ);
+        public bool IsNan => double.IsNaN(this.Real) ||
+                             double.IsNaN(this.ImagX) ||
+                             double.IsNaN(this.ImagY) ||
+                             double.IsNaN(this.ImagZ);
 
         /// <summary>
         /// Gets a value indicating whether the quaternion is not a number
         /// </summary>
-        public bool IsInfinity => double.IsInfinity(Real) ||
-                                  double.IsInfinity(ImagX) ||
-                                  double.IsInfinity(ImagY) ||
-                                  double.IsInfinity(ImagZ);
+        public bool IsInfinity => double.IsInfinity(this.Real) ||
+                                  double.IsInfinity(this.ImagX) ||
+                                  double.IsInfinity(this.ImagY) ||
+                                  double.IsInfinity(this.ImagZ);
 
         /////// <summary>
         /////// Returns a new Quaternion q with the Sign of the components.
@@ -499,9 +499,9 @@ namespace MathNet.Spatial.Euclidean
         public EulerAngles ToEulerAngles()
         {
             return new EulerAngles(
-                Angle.FromRadians(Math.Atan2(2 * ((w * x) + (y * z)), (w * w) + (z * z) - (x * x) - (y * y))),
-                Angle.FromRadians(Math.Asin(2 * ((w * y) - (x * z)))),
-                Angle.FromRadians(Math.Atan2(2 * ((w * z) + (x * y)), (w * w) + (x * x) - (y * y) - (z * z))));
+                Angle.FromRadians(Math.Atan2(2 * ((this.w * this.x) + (this.y * this.z)), (this.w * this.w) + (this.z * this.z) - (this.x * this.x) - (this.y * this.y))),
+                Angle.FromRadians(Math.Asin(2 * ((this.w * this.y) - (this.x * this.z)))),
+                Angle.FromRadians(Math.Atan2(2 * ((this.w * this.z) + (this.x * this.y)), (this.w * this.w) + (this.x * this.x) - (this.y * this.y) - (this.z * this.z))));
         }
 
         /// <summary>
@@ -526,7 +526,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A rotated quaternion</returns>
         public Quaternion RotateUnitQuaternion(Quaternion unitQuaternion)
         {
-            if (!IsUnitQuaternion)
+            if (!this.IsUnitQuaternion)
             {
                 throw new InvalidOperationException("You cannot rotate with this quaternion as it is not a Unit Quaternion");
             }
@@ -536,7 +536,7 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("The quaternion provided is not a Unit Quaternion", nameof(unitQuaternion));
             }
 
-            return (this * unitQuaternion) * Conjugate();
+            return (this * unitQuaternion) * this.Conjugate();
         }
 
         /// <summary>
@@ -545,7 +545,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new negated quaternion</returns>
         public Quaternion Negate()
         {
-            return new Quaternion(-w, -x, -y, -z);
+            return new Quaternion(-this.w, -this.x, -this.y, -this.z);
         }
 
         /// <summary>
@@ -554,7 +554,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a new conjugated quaternion</returns>
         public Quaternion Conjugate()
         {
-            return new Quaternion(w, -x, -y, -z);
+            return new Quaternion(this.w, -this.x, -this.y, -this.z);
         }
 
         /// <summary>
@@ -564,7 +564,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new quaternion</returns>
         public Quaternion Log(double lbase)
         {
-            return Log() / Math.Log(lbase);
+            return this.Log() / Math.Log(lbase);
         }
 
         /// <summary>
@@ -578,8 +578,8 @@ namespace MathNet.Spatial.Euclidean
                 return One;
             }
 
-            var quat = NormalizedVector * Arg;
-            return new Quaternion(Math.Log(Norm), quat.ImagX, quat.ImagY, quat.ImagZ);
+            var quat = this.NormalizedVector * this.Arg;
+            return new Quaternion(Math.Log(this.Norm), quat.ImagX, quat.ImagY, quat.ImagZ);
         }
 
         /// <summary>
@@ -588,7 +588,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new quaternion</returns>
         public Quaternion Log10()
         {
-            return Log() / Math.Log(10);
+            return this.Log() / Math.Log(10);
         }
 
         /// <summary>
@@ -597,8 +597,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new quaternion</returns>
         public Quaternion Exp()
         {
-            var real = Math.Pow(Math.E, Real);
-            var vector = Vector;
+            var real = Math.Pow(Math.E, this.Real);
+            var vector = this.Vector;
             var vectorNorm = vector.Norm;
             var cos = Math.Cos(vectorNorm);
             var sgn = vector == Zero ? Zero : vector / vectorNorm;
@@ -626,7 +626,7 @@ namespace MathNet.Spatial.Euclidean
                 return One;
             }
 
-            return (power * Log()).Exp();
+            return (power * this.Log()).Exp();
         }
 
         /// <summary>
@@ -636,7 +636,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new quaternion</returns>
         public Quaternion Pow(int power)
         {
-            var quat = new Quaternion(Real, ImagX, ImagY, ImagZ);
+            var quat = new Quaternion(this.Real, this.ImagX, this.ImagY, this.ImagZ);
             if (power == 0)
             {
                 return One;
@@ -672,7 +672,7 @@ namespace MathNet.Spatial.Euclidean
                 return One;
             }
 
-            return (power * Log()).Exp();
+            return (power * this.Log()).Exp();
         }
 
         /// <summary>
@@ -681,8 +681,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>The square root of the quaternion</returns>
         public Quaternion Sqrt()
         {
-            var arg = Arg * 0.5;
-            return NormalizedVector * (Math.Sin(arg) + (Math.Cos(arg) * Math.Sqrt(w)));
+            var arg = this.Arg * 0.5;
+            return this.NormalizedVector * (Math.Sin(arg) + (Math.Cos(arg) * Math.Sqrt(this.w)));
         }
 
         /// <summary>
@@ -696,13 +696,13 @@ namespace MathNet.Spatial.Euclidean
             return string.Format(
                 formatProvider,
                 "{0}{1}{2}i{3}{4}j{5}{6}k",
-                Real.ToString(format, formatProvider),
-                (ImagX < 0) ? string.Empty : "+",
-                ImagX.ToString(format, formatProvider),
-                (ImagY < 0) ? string.Empty : "+",
-                ImagY.ToString(format, formatProvider),
-                (ImagZ < 0) ? string.Empty : "+",
-                ImagZ.ToString(format, formatProvider));
+                this.Real.ToString(format, formatProvider),
+                (this.ImagX < 0) ? string.Empty : "+",
+                this.ImagX.ToString(format, formatProvider),
+                (this.ImagY < 0) ? string.Empty : "+",
+                this.ImagY.ToString(format, formatProvider),
+                (this.ImagZ < 0) ? string.Empty : "+",
+                this.ImagZ.ToString(format, formatProvider));
         }
 
         /// <summary>
@@ -713,13 +713,13 @@ namespace MathNet.Spatial.Euclidean
         {
             return string.Format(
                 "{0}{1}{2}i{3}{4}j{5}{6}k",
-                Real,
-                (ImagX < 0) ? string.Empty : "+",
-                ImagX,
-                (ImagY < 0) ? string.Empty : "+",
-                ImagY,
-                (ImagZ < 0) ? string.Empty : "+",
-                ImagZ);
+                this.Real,
+                (this.ImagX < 0) ? string.Empty : "+",
+                this.ImagX,
+                (this.ImagY < 0) ? string.Empty : "+",
+                this.ImagY,
+                (this.ImagZ < 0) ? string.Empty : "+",
+                this.ImagZ);
         }
 
         /// <summary>
@@ -731,41 +731,41 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Quaternion other, double tolerance)
         {
-            if ((other.IsNan && IsNan) ||
-                (other.IsInfinity && IsInfinity))
+            if ((other.IsNan && this.IsNan) ||
+                (other.IsInfinity && this.IsInfinity))
             {
                 return true;
             }
 
-            return Math.Abs(other.w - w) < tolerance
-                   && Math.Abs(other.x - x) < tolerance
-                   && Math.Abs(other.y - y) < tolerance
-                   && Math.Abs(other.z - z) < tolerance;
+            return Math.Abs(other.w - this.w) < tolerance
+                   && Math.Abs(other.x - this.x) < tolerance
+                   && Math.Abs(other.y - this.y) < tolerance
+                   && Math.Abs(other.z - this.z) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(Quaternion other)
         {
-            if ((other.IsNan && IsNan) ||
-                (other.IsInfinity && IsInfinity))
+            if ((other.IsNan && this.IsNan) ||
+                (other.IsInfinity && this.IsInfinity))
             {
                 return true;
             }
 
-            return w.Equals(other.w)
-                   && x.Equals(other.x)
-                   && y.Equals(other.y)
-                   && z.Equals(other.z);
+            return this.w.Equals(other.w)
+                   && this.x.Equals(other.x)
+                   && this.y.Equals(other.y)
+                   && this.z.Equals(other.z);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Quaternion q && Equals(q);
+        public override bool Equals(object obj) => obj is Quaternion q && this.Equals(q);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(w, x, y, z);
+        public override int GetHashCode() => HashCode.Combine(this.w, this.x, this.y, this.z);
 
         /// <summary>
         /// Calculates norm of quaternion from it's algebraical notation

--- a/src/Spatial/Euclidean/Quaternion.cs
+++ b/src/Spatial/Euclidean/Quaternion.cs
@@ -14,7 +14,7 @@ namespace MathNet.Spatial.Euclidean
     /// http://web.cs.iastate.edu/~cs577/handouts/quaternion.pdf
     /// http://www.lce.hut.fi/~ssarkka/pub/quat.pdf
     /// </remarks>
-    public struct Quaternion : IEquatable<Quaternion>, IFormattable
+    public readonly struct Quaternion : IEquatable<Quaternion>, IFormattable
     {
         /// <summary>
         /// Neutral element for multiplication
@@ -55,10 +55,10 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="imagZ">The Z-value of the vector component of the Quaternion</param>
         public Quaternion(double real, double imagX, double imagY, double imagZ)
         {
-            this.x = imagX;
-            this.y = imagY;
-            this.z = imagZ;
-            this.w = real;
+            x = imagX;
+            y = imagY;
+            z = imagZ;
+            w = real;
         }
 
         /// <summary>
@@ -74,39 +74,39 @@ namespace MathNet.Spatial.Euclidean
         /// <summary>
         /// Gets the real part of the quaternion.
         /// </summary>
-        public double Real => this.w;
+        public double Real => w;
 
         /// <summary>
         /// Gets the imaginary X part (coefficient of complex I) of the quaternion.
         /// </summary>
-        public double ImagX => this.x;
+        public double ImagX => x;
 
         /// <summary>
         /// Gets the imaginary Y part (coefficient of complex J) of the quaternion.
         /// </summary>
-        public double ImagY => this.y;
+        public double ImagY => y;
 
         /// <summary>
         /// Gets the imaginary Z part (coefficient of complex K) of the quaternion.
         /// </summary>
-        public double ImagZ => this.z;
+        public double ImagZ => z;
 
         /// <summary>
         /// Gets the sum of the squares of the four components.
         /// </summary>
-        public double NormSquared => ToNormSquared(this.Real, this.ImagX, this.ImagY, this.ImagZ);
+        public double NormSquared => ToNormSquared(Real, ImagX, ImagY, ImagZ);
 
         /// <summary>
         /// Gets the norm of the quaternion q: square root of the sum of the squares of the four components.
         /// </summary>
-        public double Norm => Math.Sqrt(this.NormSquared);
+        public double Norm => Math.Sqrt(NormSquared);
 
         /// <summary>
         /// Gets the argument phi = arg(q) of the quaternion q, such that q = r*(cos(phi) +
         /// u*sin(phi)) = r*exp(phi*u) where r is the absolute and u the unit vector of
         /// q.
         /// </summary>
-        public double Arg => Math.Acos(this.Real / this.Norm);
+        public double Arg => Math.Acos(Real / Norm);
 
         /// <summary>
         /// Gets a value indicating whether the quaternion q has length |q| = 1.
@@ -115,29 +115,29 @@ namespace MathNet.Spatial.Euclidean
         /// To normalize a quaternion to a length of 1, use the <see cref="Normalized"/> method.
         /// All unit quaternions form a 3-sphere.
         /// </remarks>
-        public bool IsUnitQuaternion => this.NormSquared.AlmostEqual(1);
+        public bool IsUnitQuaternion => NormSquared.AlmostEqual(1);
 
         /// <summary>
         /// Gets a new Quaternion q with the Scalar part only.
         /// If you need a Double, use the Real-Field instead.
         /// </summary>
-        public Quaternion Scalar => new Quaternion(this.w, 0, 0, 0);
+        public Quaternion Scalar => new Quaternion(w, 0, 0, 0);
 
         /// <summary>
         /// Gets a new Quaternion q with the Vector part only.
         /// </summary>
-        public Quaternion Vector => new Quaternion(0, this.x, this.y, this.z);
+        public Quaternion Vector => new Quaternion(0, x, y, z);
 
         /// <summary>
         /// Gets a new normalized Quaternion u with the Vector part only, such that ||u|| = 1.
         /// Q may then be represented as q = r*(cos(phi) + u*sin(phi)) = r*exp(phi*u) where r is the absolute and phi the argument of q.
         /// </summary>
-        public Quaternion NormalizedVector => ToUnitQuaternion(0, this.x, this.y, this.z);
+        public Quaternion NormalizedVector => ToUnitQuaternion(0, x, y, z);
 
         /// <summary>
         /// Gets a new normalized Quaternion q with the direction of this quaternion.
         /// </summary>
-        public Quaternion Normalized => this == Zero ? this : ToUnitQuaternion(this.w, this.x, this.y, this.z);
+        public Quaternion Normalized => this == Zero ? this : ToUnitQuaternion(w, x, y, z);
 
         /// <summary>
         /// Gets an inverted quaternion. Inversing Zero returns Zero
@@ -151,26 +151,26 @@ namespace MathNet.Spatial.Euclidean
                     return this;
                 }
 
-                var normSquared = this.NormSquared;
-                return new Quaternion(this.w / normSquared, -this.x / normSquared, -this.y / normSquared, -this.z / normSquared);
+                var normSquared = NormSquared;
+                return new Quaternion(w / normSquared, -x / normSquared, -y / normSquared, -z / normSquared);
             }
         }
 
         /// <summary>
         /// Gets a value indicating whether the quaternion is not a number
         /// </summary>
-        public bool IsNan => double.IsNaN(this.Real) ||
-                             double.IsNaN(this.ImagX) ||
-                             double.IsNaN(this.ImagY) ||
-                             double.IsNaN(this.ImagZ);
+        public bool IsNan => double.IsNaN(Real) ||
+                             double.IsNaN(ImagX) ||
+                             double.IsNaN(ImagY) ||
+                             double.IsNaN(ImagZ);
 
         /// <summary>
         /// Gets a value indicating whether the quaternion is not a number
         /// </summary>
-        public bool IsInfinity => double.IsInfinity(this.Real) ||
-                                  double.IsInfinity(this.ImagX) ||
-                                  double.IsInfinity(this.ImagY) ||
-                                  double.IsInfinity(this.ImagZ);
+        public bool IsInfinity => double.IsInfinity(Real) ||
+                                  double.IsInfinity(ImagX) ||
+                                  double.IsInfinity(ImagY) ||
+                                  double.IsInfinity(ImagZ);
 
         /////// <summary>
         /////// Returns a new Quaternion q with the Sign of the components.
@@ -499,9 +499,9 @@ namespace MathNet.Spatial.Euclidean
         public EulerAngles ToEulerAngles()
         {
             return new EulerAngles(
-                Angle.FromRadians(Math.Atan2(2 * ((this.w * this.x) + (this.y * this.z)), (this.w * this.w) + (this.z * this.z) - (this.x * this.x) - (this.y * this.y))),
-                Angle.FromRadians(Math.Asin(2 * ((this.w * this.y) - (this.x * this.z)))),
-                Angle.FromRadians(Math.Atan2(2 * ((this.w * this.z) + (this.x * this.y)), (this.w * this.w) + (this.x * this.x) - (this.y * this.y) - (this.z * this.z))));
+                Angle.FromRadians(Math.Atan2(2 * ((w * x) + (y * z)), (w * w) + (z * z) - (x * x) - (y * y))),
+                Angle.FromRadians(Math.Asin(2 * ((w * y) - (x * z)))),
+                Angle.FromRadians(Math.Atan2(2 * ((w * z) + (x * y)), (w * w) + (x * x) - (y * y) - (z * z))));
         }
 
         /// <summary>
@@ -526,7 +526,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A rotated quaternion</returns>
         public Quaternion RotateUnitQuaternion(Quaternion unitQuaternion)
         {
-            if (!this.IsUnitQuaternion)
+            if (!IsUnitQuaternion)
             {
                 throw new InvalidOperationException("You cannot rotate with this quaternion as it is not a Unit Quaternion");
             }
@@ -536,7 +536,7 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("The quaternion provided is not a Unit Quaternion", nameof(unitQuaternion));
             }
 
-            return (this * unitQuaternion) * this.Conjugate();
+            return (this * unitQuaternion) * Conjugate();
         }
 
         /// <summary>
@@ -545,7 +545,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new negated quaternion</returns>
         public Quaternion Negate()
         {
-            return new Quaternion(-this.w, -this.x, -this.y, -this.z);
+            return new Quaternion(-w, -x, -y, -z);
         }
 
         /// <summary>
@@ -554,7 +554,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>a new conjugated quaternion</returns>
         public Quaternion Conjugate()
         {
-            return new Quaternion(this.w, -this.x, -this.y, -this.z);
+            return new Quaternion(w, -x, -y, -z);
         }
 
         /// <summary>
@@ -564,7 +564,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new quaternion</returns>
         public Quaternion Log(double lbase)
         {
-            return this.Log() / Math.Log(lbase);
+            return Log() / Math.Log(lbase);
         }
 
         /// <summary>
@@ -578,8 +578,8 @@ namespace MathNet.Spatial.Euclidean
                 return One;
             }
 
-            var quat = this.NormalizedVector * this.Arg;
-            return new Quaternion(Math.Log(this.Norm), quat.ImagX, quat.ImagY, quat.ImagZ);
+            var quat = NormalizedVector * Arg;
+            return new Quaternion(Math.Log(Norm), quat.ImagX, quat.ImagY, quat.ImagZ);
         }
 
         /// <summary>
@@ -588,7 +588,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new quaternion</returns>
         public Quaternion Log10()
         {
-            return this.Log() / Math.Log(10);
+            return Log() / Math.Log(10);
         }
 
         /// <summary>
@@ -597,8 +597,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new quaternion</returns>
         public Quaternion Exp()
         {
-            var real = Math.Pow(Math.E, this.Real);
-            var vector = this.Vector;
+            var real = Math.Pow(Math.E, Real);
+            var vector = Vector;
             var vectorNorm = vector.Norm;
             var cos = Math.Cos(vectorNorm);
             var sgn = vector == Zero ? Zero : vector / vectorNorm;
@@ -626,7 +626,7 @@ namespace MathNet.Spatial.Euclidean
                 return One;
             }
 
-            return (power * this.Log()).Exp();
+            return (power * Log()).Exp();
         }
 
         /// <summary>
@@ -636,7 +636,7 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>A new quaternion</returns>
         public Quaternion Pow(int power)
         {
-            var quat = new Quaternion(this.Real, this.ImagX, this.ImagY, this.ImagZ);
+            var quat = new Quaternion(Real, ImagX, ImagY, ImagZ);
             if (power == 0)
             {
                 return One;
@@ -672,7 +672,7 @@ namespace MathNet.Spatial.Euclidean
                 return One;
             }
 
-            return (power * this.Log()).Exp();
+            return (power * Log()).Exp();
         }
 
         /// <summary>
@@ -681,8 +681,8 @@ namespace MathNet.Spatial.Euclidean
         /// <returns>The square root of the quaternion</returns>
         public Quaternion Sqrt()
         {
-            var arg = this.Arg * 0.5;
-            return this.NormalizedVector * (Math.Sin(arg) + (Math.Cos(arg) * Math.Sqrt(this.w)));
+            var arg = Arg * 0.5;
+            return NormalizedVector * (Math.Sin(arg) + (Math.Cos(arg) * Math.Sqrt(w)));
         }
 
         /// <summary>
@@ -696,13 +696,13 @@ namespace MathNet.Spatial.Euclidean
             return string.Format(
                 formatProvider,
                 "{0}{1}{2}i{3}{4}j{5}{6}k",
-                this.Real.ToString(format, formatProvider),
-                (this.ImagX < 0) ? string.Empty : "+",
-                this.ImagX.ToString(format, formatProvider),
-                (this.ImagY < 0) ? string.Empty : "+",
-                this.ImagY.ToString(format, formatProvider),
-                (this.ImagZ < 0) ? string.Empty : "+",
-                this.ImagZ.ToString(format, formatProvider));
+                Real.ToString(format, formatProvider),
+                (ImagX < 0) ? string.Empty : "+",
+                ImagX.ToString(format, formatProvider),
+                (ImagY < 0) ? string.Empty : "+",
+                ImagY.ToString(format, formatProvider),
+                (ImagZ < 0) ? string.Empty : "+",
+                ImagZ.ToString(format, formatProvider));
         }
 
         /// <summary>
@@ -713,13 +713,13 @@ namespace MathNet.Spatial.Euclidean
         {
             return string.Format(
                 "{0}{1}{2}i{3}{4}j{5}{6}k",
-                this.Real,
-                (this.ImagX < 0) ? string.Empty : "+",
-                this.ImagX,
-                (this.ImagY < 0) ? string.Empty : "+",
-                this.ImagY,
-                (this.ImagZ < 0) ? string.Empty : "+",
-                this.ImagZ);
+                Real,
+                (ImagX < 0) ? string.Empty : "+",
+                ImagX,
+                (ImagY < 0) ? string.Empty : "+",
+                ImagY,
+                (ImagZ < 0) ? string.Empty : "+",
+                ImagZ);
         }
 
         /// <summary>
@@ -731,41 +731,41 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Quaternion other, double tolerance)
         {
-            if ((other.IsNan && this.IsNan) ||
-                (other.IsInfinity && this.IsInfinity))
+            if ((other.IsNan && IsNan) ||
+                (other.IsInfinity && IsInfinity))
             {
                 return true;
             }
 
-            return Math.Abs(other.w - this.w) < tolerance
-                   && Math.Abs(other.x - this.x) < tolerance
-                   && Math.Abs(other.y - this.y) < tolerance
-                   && Math.Abs(other.z - this.z) < tolerance;
+            return Math.Abs(other.w - w) < tolerance
+                   && Math.Abs(other.x - x) < tolerance
+                   && Math.Abs(other.y - y) < tolerance
+                   && Math.Abs(other.z - z) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(Quaternion other)
         {
-            if ((other.IsNan && this.IsNan) ||
-                (other.IsInfinity && this.IsInfinity))
+            if ((other.IsNan && IsNan) ||
+                (other.IsInfinity && IsInfinity))
             {
                 return true;
             }
 
-            return this.w.Equals(other.w)
-                   && this.x.Equals(other.x)
-                   && this.y.Equals(other.y)
-                   && this.z.Equals(other.z);
+            return w.Equals(other.w)
+                   && x.Equals(other.x)
+                   && y.Equals(other.y)
+                   && z.Equals(other.z);
         }
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Quaternion q && this.Equals(q);
+        public override bool Equals(object obj) => obj is Quaternion q && Equals(q);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.w, this.x, this.y, this.z);
+        public override int GetHashCode() => HashCode.Combine(w, x, y, z);
 
         /// <summary>
         /// Calculates norm of quaternion from it's algebraical notation

--- a/src/Spatial/Euclidean/Ray3D.cs
+++ b/src/Spatial/Euclidean/Ray3D.cs
@@ -33,8 +33,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="direction">The direction of the ray.</param>
         public Ray3D(Point3D throughPoint, UnitVector3D direction)
         {
-            this.ThroughPoint = throughPoint;
-            this.Direction = direction;
+            ThroughPoint = throughPoint;
+            Direction = direction;
         }
 
         /// <summary>
@@ -101,9 +101,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public LineSegment3D ShortestLineTo(Point3D point3D)
         {
-            var v = this.ThroughPoint.VectorTo(point3D);
-            var alongVector = v.ProjectOn(this.Direction);
-            return new LineSegment3D(this.ThroughPoint + alongVector, point3D);
+            var v = ThroughPoint.VectorTo(point3D);
+            var alongVector = v.ProjectOn(Direction);
+            return new LineSegment3D(ThroughPoint + alongVector, point3D);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsCollinear(Ray3D otherRay, double tolerance = float.Epsilon)
         {
-            return this.Direction.IsParallelTo(otherRay.Direction, tolerance);
+            return Direction.IsParallelTo(otherRay.Direction, tolerance);
         }
 
         /// <summary>
@@ -138,27 +138,27 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Ray3D other, double tolerance)
         {
-            return this.Direction.Equals(other.Direction, tolerance) &&
-                   this.ThroughPoint.Equals(other.ThroughPoint, tolerance);
+            return Direction.Equals(other.Direction, tolerance) &&
+                   ThroughPoint.Equals(other.ThroughPoint, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
-        public bool Equals(Ray3D r) => this.Direction.Equals(r.Direction) && this.ThroughPoint.Equals(r.ThroughPoint);
+        public bool Equals(Ray3D r) => Direction.Equals(r.Direction) && ThroughPoint.Equals(r.ThroughPoint);
 
         /// <inheritdoc/>
         [Pure]
-        public override bool Equals(object obj) => obj is Ray3D r && this.Equals(r);
+        public override bool Equals(object obj) => obj is Ray3D r && Equals(r);
 
         /// <inheritdoc/>
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.ThroughPoint, this.Direction);
+        public override int GetHashCode() => HashCode.Combine(ThroughPoint, Direction);
 
         /// <inheritdoc/>
         [Pure]
         public override string ToString()
         {
-            return this.ToString("G15", CultureInfo.InvariantCulture);
+            return ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <inheritdoc/>
@@ -167,8 +167,8 @@ namespace MathNet.Spatial.Euclidean
         {
             return string.Format(
                 "ThroughPoint: {0}, Direction: {1}",
-                this.ThroughPoint.ToString(format, formatProvider),
-                this.Direction.ToString(format, formatProvider));
+                ThroughPoint.ToString(format, formatProvider),
+                Direction.ToString(format, formatProvider));
         }
 
         /// <inheritdoc/>
@@ -190,8 +190,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc/>
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteElement("ThroughPoint", this.ThroughPoint);
-            writer.WriteElement("Direction", this.Direction);
+            writer.WriteElement("ThroughPoint", ThroughPoint);
+            writer.WriteElement("Direction", Direction);
         }
     }
 }

--- a/src/Spatial/Euclidean/Ray3D.cs
+++ b/src/Spatial/Euclidean/Ray3D.cs
@@ -33,8 +33,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="direction">The direction of the ray.</param>
         public Ray3D(Point3D throughPoint, UnitVector3D direction)
         {
-            ThroughPoint = throughPoint;
-            Direction = direction;
+            this.ThroughPoint = throughPoint;
+            this.Direction = direction;
         }
 
         /// <summary>
@@ -101,9 +101,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public LineSegment3D ShortestLineTo(Point3D point3D)
         {
-            var v = ThroughPoint.VectorTo(point3D);
-            var alongVector = v.ProjectOn(Direction);
-            return new LineSegment3D(ThroughPoint + alongVector, point3D);
+            var v = this.ThroughPoint.VectorTo(point3D);
+            var alongVector = v.ProjectOn(this.Direction);
+            return new LineSegment3D(this.ThroughPoint + alongVector, point3D);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsCollinear(Ray3D otherRay, double tolerance = float.Epsilon)
         {
-            return Direction.IsParallelTo(otherRay.Direction, tolerance);
+            return this.Direction.IsParallelTo(otherRay.Direction, tolerance);
         }
 
         /// <summary>
@@ -138,27 +138,27 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool Equals(Ray3D other, double tolerance)
         {
-            return Direction.Equals(other.Direction, tolerance) &&
-                   ThroughPoint.Equals(other.ThroughPoint, tolerance);
+            return this.Direction.Equals(other.Direction, tolerance) &&
+                   this.ThroughPoint.Equals(other.ThroughPoint, tolerance);
         }
 
         /// <inheritdoc/>
         [Pure]
-        public bool Equals(Ray3D r) => Direction.Equals(r.Direction) && ThroughPoint.Equals(r.ThroughPoint);
+        public bool Equals(Ray3D r) => this.Direction.Equals(r.Direction) && this.ThroughPoint.Equals(r.ThroughPoint);
 
         /// <inheritdoc/>
         [Pure]
-        public override bool Equals(object obj) => obj is Ray3D r && Equals(r);
+        public override bool Equals(object obj) => obj is Ray3D r && this.Equals(r);
 
         /// <inheritdoc/>
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(ThroughPoint, Direction);
+        public override int GetHashCode() => HashCode.Combine(this.ThroughPoint, this.Direction);
 
         /// <inheritdoc/>
         [Pure]
         public override string ToString()
         {
-            return ToString("G15", CultureInfo.InvariantCulture);
+            return this.ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <inheritdoc/>
@@ -167,8 +167,8 @@ namespace MathNet.Spatial.Euclidean
         {
             return string.Format(
                 "ThroughPoint: {0}, Direction: {1}",
-                ThroughPoint.ToString(format, formatProvider),
-                Direction.ToString(format, formatProvider));
+                this.ThroughPoint.ToString(format, formatProvider),
+                this.Direction.ToString(format, formatProvider));
         }
 
         /// <inheritdoc/>
@@ -190,8 +190,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc/>
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteElement("ThroughPoint", ThroughPoint);
-            writer.WriteElement("Direction", Direction);
+            writer.WriteElement("ThroughPoint", this.ThroughPoint);
+            writer.WriteElement("Direction", this.Direction);
         }
     }
 }

--- a/src/Spatial/Euclidean/UnitVector3D.cs
+++ b/src/Spatial/Euclidean/UnitVector3D.cs
@@ -62,9 +62,9 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("l < float.Epsilon");
             }
 
-            this.X = x / norm;
-            this.Y = y / norm;
-            this.Z = z / norm;
+            X = x / norm;
+            Y = y / norm;
+            Z = z / norm;
         }
 
         /// <summary>
@@ -90,12 +90,12 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                if (-this.X - this.Y > 0.1)
+                if (-X - Y > 0.1)
                 {
-                    return Create(this.Z, this.Z, -this.X - this.Y);
+                    return Create(Z, Z, -X - Y);
                 }
 
-                return Create(-this.Y - this.Z, this.X, this.X);
+                return Create(-Y - Z, X, X);
             }
         }
 
@@ -109,7 +109,7 @@ namespace MathNet.Spatial.Euclidean
         /// Gets the cross product matrix
         /// </summary>
         [Pure]
-        internal Matrix<double> CrossProductMatrix => Matrix<double>.Build.Dense(3, 3, new[] { 0d, this.Z, -this.Y, -this.Z, 0d, this.X, this.Y, -this.X, 0d });
+        internal Matrix<double> CrossProductMatrix => Matrix<double>.Build.Dense(3, 3, new[] { 0d, Z, -Y, -Z, 0d, X, Y, -X, 0d });
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified vectors is equal.
@@ -409,7 +409,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Ray3D ProjectOn(Plane plane)
         {
-            return plane.Project(this.ToVector3D());
+            return plane.Project(ToVector3D());
         }
 
         /// <summary>
@@ -420,7 +420,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D ProjectOn(UnitVector3D uv)
         {
-            var pd = this.DotProduct(uv);
+            var pd = DotProduct(uv);
             return pd * this;
         }
 
@@ -435,7 +435,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsParallelTo(Vector3D othervector, double tolerance = 1e-10)
         {
             var other = othervector.Normalize();
-            return this.IsParallelTo(other, tolerance);
+            return IsParallelTo(other, tolerance);
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace MathNet.Spatial.Euclidean
         {
             // This is the master method for all Vector3D and UnitVector3D IsParallelTo comparisons.  Everything else
             // ends up here sooner or later.
-            var dp = Math.Abs(this.DotProduct(othervector));
+            var dp = Math.Abs(DotProduct(othervector));
             return Math.Abs(1 - dp) <= tolerance;
         }
 
@@ -464,7 +464,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsParallelTo(UnitVector3D othervector, Angle angleTolerance)
         {
             // Compute the angle between these vectors
-            var angle = this.AngleTo(othervector);
+            var angle = AngleTo(othervector);
 
             // Compute the 180° opposite of the angle
             var opposite = Angle.FromDegrees(180) - angle;
@@ -483,7 +483,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsParallelTo(Vector3D othervector, Angle angleTolerance)
         {
             var other = othervector.Normalize();
-            return this.IsParallelTo(other, angleTolerance);
+            return IsParallelTo(other, angleTolerance);
         }
 
         /// <summary>
@@ -497,7 +497,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsPerpendicularTo(Vector3D othervector, double tolerance = 1e-10)
         {
             var other = othervector.Normalize();
-            return Math.Abs(this.DotProduct(other)) < tolerance;
+            return Math.Abs(DotProduct(other)) < tolerance;
         }
 
         /// <summary>
@@ -510,7 +510,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsPerpendicularTo(UnitVector3D othervector, double tolerance = 1e-10)
         {
-            return Math.Abs(this.DotProduct(othervector)) < tolerance;
+            return Math.Abs(DotProduct(othervector)) < tolerance;
         }
 
         /// <summary>
@@ -520,7 +520,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public UnitVector3D Negate()
         {
-            return Create(-1 * this.X, -1 * this.Y, -1 * this.Z);
+            return Create(-1 * X, -1 * Y, -1 * Z);
         }
 
         /// <summary>
@@ -531,7 +531,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DotProduct(Vector3D v)
         {
-            return (this.X * v.X) + (this.Y * v.Y) + (this.Z * v.Z);
+            return (X * v.X) + (Y * v.Y) + (Z * v.Z);
         }
 
         /// <summary>
@@ -542,7 +542,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DotProduct(UnitVector3D v)
         {
-            var dp = (this.X * v.X) + (this.Y * v.Y) + (this.Z * v.Z);
+            var dp = (X * v.X) + (Y * v.Y) + (Z * v.Z);
             return Math.Max(-1, Math.Min(dp, 1));
         }
 
@@ -554,9 +554,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public UnitVector3D CrossProduct(UnitVector3D other)
         {
-            var x = (this.Y * other.Z) - (this.Z * other.Y);
-            var y = (this.Z * other.X) - (this.X * other.Z);
-            var z = (this.X * other.Y) - (this.Y * other.X);
+            var x = (Y * other.Z) - (Z * other.Y);
+            var y = (Z * other.X) - (X * other.Z);
+            var z = (X * other.Y) - (Y * other.X);
             var v = Create(x, y, z);
             return v;
         }
@@ -569,9 +569,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D CrossProduct(Vector3D inVector3D)
         {
-            var x = (this.Y * inVector3D.Z) - (this.Z * inVector3D.Y);
-            var y = (this.Z * inVector3D.X) - (this.X * inVector3D.Z);
-            var z = (this.X * inVector3D.Y) - (this.Y * inVector3D.X);
+            var x = (Y * inVector3D.Z) - (Z * inVector3D.Y);
+            var y = (Z * inVector3D.X) - (X * inVector3D.Z);
+            var z = (X * inVector3D.Y) - (Y * inVector3D.X);
             var v = new Vector3D(x, y, z);
             return v;
         }
@@ -584,10 +584,10 @@ namespace MathNet.Spatial.Euclidean
         public Matrix<double> GetUnitTensorProduct()
         {
             // unitTensorProduct:matrix([ux^2,ux*uy,ux*uz],[ux*uy,uy^2,uy*uz],[ux*uz,uy*uz,uz^2]),
-            var xy = this.X * this.Y;
-            var xz = this.X * this.Z;
-            var yz = this.Y * this.Z;
-            return Matrix<double>.Build.Dense(3, 3, new[] { this.X * this.X, xy, xz, xy, this.Y * this.Y, yz, xz, yz, this.Z * this.Z });
+            var xy = X * Y;
+            var xz = X * Z;
+            var yz = Y * Z;
+            return Matrix<double>.Build.Dense(3, 3, new[] { X * X, xy, xz, xy, Y * Y, yz, xz, yz, Z * Z });
         }
 
         /// <summary>
@@ -599,7 +599,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Angle SignedAngleTo(Vector3D v, UnitVector3D about)
         {
-            return this.SignedAngleTo(v.Normalize(), about);
+            return SignedAngleTo(v.Normalize(), about);
         }
 
         /// <summary>
@@ -611,7 +611,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Angle SignedAngleTo(UnitVector3D v, UnitVector3D about)
         {
-            if (this.IsParallelTo(about))
+            if (IsParallelTo(about))
             {
                 throw new ArgumentException("FromVector parallel to aboutVector");
             }
@@ -622,7 +622,7 @@ namespace MathNet.Spatial.Euclidean
             }
 
             var rp = new Plane(new Point3D(0, 0, 0), about);
-            var pfv = this.ProjectOn(rp).Direction;
+            var pfv = ProjectOn(rp).Direction;
             var ptv = v.ProjectOn(rp).Direction;
             var dp = pfv.DotProduct(ptv);
             if (Math.Abs(dp - 1) < 1E-15)
@@ -650,7 +650,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Angle AngleTo(Vector3D v)
         {
-            return this.AngleTo(v.Normalize());
+            return AngleTo(v.Normalize());
         }
 
         /// <summary>
@@ -661,7 +661,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Angle AngleTo(UnitVector3D v)
         {
-            var dp = this.DotProduct(v);
+            var dp = DotProduct(v);
             var angle = Math.Acos(dp);
             return Angle.FromRadians(angle);
         }
@@ -686,7 +686,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D ToPoint3D()
         {
-            return new Point3D(this.X, this.Y, this.Z);
+            return new Point3D(X, Y, Z);
         }
 
         /// <summary>
@@ -696,7 +696,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D ToVector3D()
         {
-            return new Vector3D(this.X, this.Y, this.Z);
+            return new Vector3D(X, Y, Z);
         }
 
         /// <summary>
@@ -707,7 +707,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D TransformBy(CoordinateSystem coordinateSystem)
         {
-            return coordinateSystem.Transform(this.ToVector3D());
+            return coordinateSystem.Transform(ToVector3D());
         }
 
         /// <summary>
@@ -718,7 +718,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D TransformBy(Matrix<double> m)
         {
-            return Vector3D.OfVector(m.Multiply(this.ToVector()));
+            return Vector3D.OfVector(m.Multiply(ToVector()));
         }
 
         /// <summary>
@@ -728,14 +728,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { this.X, this.Y, this.Z });
+            return Vector<double>.Build.Dense(new[] { X, Y, Z });
         }
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return this.ToString("G15", CultureInfo.InvariantCulture);
+            return ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -746,7 +746,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public string ToString(IFormatProvider provider)
         {
-            return this.ToString("G15", provider);
+            return ToString("G15", provider);
         }
 
         /// <inheritdoc/>
@@ -755,7 +755,7 @@ namespace MathNet.Spatial.Euclidean
         {
             var numberFormatInfo = provider != null ? NumberFormatInfo.GetInstance(provider) : CultureInfo.InvariantCulture.NumberFormat;
             var separator = numberFormatInfo.NumberDecimalSeparator == "," ? ";" : ",";
-            return string.Format("({0}{1} {2}{1} {3})", this.X.ToString(format, numberFormatInfo), separator, this.Y.ToString(format, numberFormatInfo), this.Z.ToString(format, numberFormatInfo));
+            return string.Format("({0}{1} {2}{1} {3})", X.ToString(format, numberFormatInfo), separator, Y.ToString(format, numberFormatInfo), Z.ToString(format, numberFormatInfo));
         }
 
         /// <summary>
@@ -772,9 +772,9 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - this.X) < tolerance &&
-                   Math.Abs(other.Y - this.Y) < tolerance &&
-                   Math.Abs(other.Z - this.Z) < tolerance;
+            return Math.Abs(other.X - X) < tolerance &&
+                   Math.Abs(other.Y - Y) < tolerance &&
+                   Math.Abs(other.Z - Z) < tolerance;
         }
 
         /// <summary>
@@ -791,35 +791,35 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - this.X) < tolerance &&
-                   Math.Abs(other.Y - this.Y) < tolerance &&
-                   Math.Abs(other.Z - this.Z) < tolerance;
+            return Math.Abs(other.X - X) < tolerance &&
+                   Math.Abs(other.Y - Y) < tolerance &&
+                   Math.Abs(other.Z - Z) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(Vector3D other)
         {
-            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
+            return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(UnitVector3D other)
         {
-            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
+            return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
         }
 
         /// <inheritdoc />
         [Pure]
         public override bool Equals(object obj)
         {
-            return (obj is UnitVector3D u && this.Equals(u)) || (obj is Vector3D v && this.Equals(v));
+            return (obj is UnitVector3D u && Equals(u)) || (obj is Vector3D v && Equals(v));
         }
 
         /// <inheritdoc/>
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z);
+        public override int GetHashCode() => HashCode.Combine(X, Y, Z);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema()
@@ -861,15 +861,15 @@ namespace MathNet.Spatial.Euclidean
                 return;
             }
 
-            throw new XmlException($"Could not read a {this.GetType()}");
+            throw new XmlException($"Could not read a {GetType()}");
         }
 
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteAttribute("X", this.X);
-            writer.WriteAttribute("Y", this.Y);
-            writer.WriteAttribute("Z", this.Z);
+            writer.WriteAttribute("X", X);
+            writer.WriteAttribute("Y", Y);
+            writer.WriteAttribute("Z", Z);
         }
 
         /// <summary>
@@ -880,7 +880,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         internal double DotProduct(Point3D v)
         {
-            return (this.X * v.X) + (this.Y * v.Y) + (this.Z * v.Z);
+            return (X * v.X) + (Y * v.Y) + (Z * v.Z);
         }
     }
 }

--- a/src/Spatial/Euclidean/UnitVector3D.cs
+++ b/src/Spatial/Euclidean/UnitVector3D.cs
@@ -62,9 +62,9 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("l < float.Epsilon");
             }
 
-            X = x / norm;
-            Y = y / norm;
-            Z = z / norm;
+            this.X = x / norm;
+            this.Y = y / norm;
+            this.Z = z / norm;
         }
 
         /// <summary>
@@ -90,12 +90,12 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                if (-X - Y > 0.1)
+                if (-this.X - this.Y > 0.1)
                 {
-                    return Create(Z, Z, -X - Y);
+                    return Create(this.Z, this.Z, -this.X - this.Y);
                 }
 
-                return Create(-Y - Z, X, X);
+                return Create(-this.Y - this.Z, this.X, this.X);
             }
         }
 
@@ -109,7 +109,7 @@ namespace MathNet.Spatial.Euclidean
         /// Gets the cross product matrix
         /// </summary>
         [Pure]
-        internal Matrix<double> CrossProductMatrix => Matrix<double>.Build.Dense(3, 3, new[] { 0d, Z, -Y, -Z, 0d, X, Y, -X, 0d });
+        internal Matrix<double> CrossProductMatrix => Matrix<double>.Build.Dense(3, 3, new[] { 0d, this.Z, -this.Y, -this.Z, 0d, this.X, this.Y, -this.X, 0d });
 
         /// <summary>
         /// Returns a value that indicates whether each pair of elements in two specified vectors is equal.
@@ -409,7 +409,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Ray3D ProjectOn(Plane plane)
         {
-            return plane.Project(ToVector3D());
+            return plane.Project(this.ToVector3D());
         }
 
         /// <summary>
@@ -420,7 +420,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D ProjectOn(UnitVector3D uv)
         {
-            var pd = DotProduct(uv);
+            var pd = this.DotProduct(uv);
             return pd * this;
         }
 
@@ -435,7 +435,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsParallelTo(Vector3D othervector, double tolerance = 1e-10)
         {
             var other = othervector.Normalize();
-            return IsParallelTo(other, tolerance);
+            return this.IsParallelTo(other, tolerance);
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace MathNet.Spatial.Euclidean
         {
             // This is the master method for all Vector3D and UnitVector3D IsParallelTo comparisons.  Everything else
             // ends up here sooner or later.
-            var dp = Math.Abs(DotProduct(othervector));
+            var dp = Math.Abs(this.DotProduct(othervector));
             return Math.Abs(1 - dp) <= tolerance;
         }
 
@@ -464,7 +464,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsParallelTo(UnitVector3D othervector, Angle angleTolerance)
         {
             // Compute the angle between these vectors
-            var angle = AngleTo(othervector);
+            var angle = this.AngleTo(othervector);
 
             // Compute the 180° opposite of the angle
             var opposite = Angle.FromDegrees(180) - angle;
@@ -483,7 +483,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsParallelTo(Vector3D othervector, Angle angleTolerance)
         {
             var other = othervector.Normalize();
-            return IsParallelTo(other, angleTolerance);
+            return this.IsParallelTo(other, angleTolerance);
         }
 
         /// <summary>
@@ -497,7 +497,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsPerpendicularTo(Vector3D othervector, double tolerance = 1e-10)
         {
             var other = othervector.Normalize();
-            return Math.Abs(DotProduct(other)) < tolerance;
+            return Math.Abs(this.DotProduct(other)) < tolerance;
         }
 
         /// <summary>
@@ -510,7 +510,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsPerpendicularTo(UnitVector3D othervector, double tolerance = 1e-10)
         {
-            return Math.Abs(DotProduct(othervector)) < tolerance;
+            return Math.Abs(this.DotProduct(othervector)) < tolerance;
         }
 
         /// <summary>
@@ -520,7 +520,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public UnitVector3D Negate()
         {
-            return Create(-1 * X, -1 * Y, -1 * Z);
+            return Create(-1 * this.X, -1 * this.Y, -1 * this.Z);
         }
 
         /// <summary>
@@ -531,7 +531,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DotProduct(Vector3D v)
         {
-            return (X * v.X) + (Y * v.Y) + (Z * v.Z);
+            return (this.X * v.X) + (this.Y * v.Y) + (this.Z * v.Z);
         }
 
         /// <summary>
@@ -542,7 +542,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DotProduct(UnitVector3D v)
         {
-            var dp = (X * v.X) + (Y * v.Y) + (Z * v.Z);
+            var dp = (this.X * v.X) + (this.Y * v.Y) + (this.Z * v.Z);
             return Math.Max(-1, Math.Min(dp, 1));
         }
 
@@ -554,9 +554,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public UnitVector3D CrossProduct(UnitVector3D other)
         {
-            var x = (Y * other.Z) - (Z * other.Y);
-            var y = (Z * other.X) - (X * other.Z);
-            var z = (X * other.Y) - (Y * other.X);
+            var x = (this.Y * other.Z) - (this.Z * other.Y);
+            var y = (this.Z * other.X) - (this.X * other.Z);
+            var z = (this.X * other.Y) - (this.Y * other.X);
             var v = Create(x, y, z);
             return v;
         }
@@ -569,9 +569,9 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D CrossProduct(Vector3D inVector3D)
         {
-            var x = (Y * inVector3D.Z) - (Z * inVector3D.Y);
-            var y = (Z * inVector3D.X) - (X * inVector3D.Z);
-            var z = (X * inVector3D.Y) - (Y * inVector3D.X);
+            var x = (this.Y * inVector3D.Z) - (this.Z * inVector3D.Y);
+            var y = (this.Z * inVector3D.X) - (this.X * inVector3D.Z);
+            var z = (this.X * inVector3D.Y) - (this.Y * inVector3D.X);
             var v = new Vector3D(x, y, z);
             return v;
         }
@@ -584,10 +584,10 @@ namespace MathNet.Spatial.Euclidean
         public Matrix<double> GetUnitTensorProduct()
         {
             // unitTensorProduct:matrix([ux^2,ux*uy,ux*uz],[ux*uy,uy^2,uy*uz],[ux*uz,uy*uz,uz^2]),
-            var xy = X * Y;
-            var xz = X * Z;
-            var yz = Y * Z;
-            return Matrix<double>.Build.Dense(3, 3, new[] { X * X, xy, xz, xy, Y * Y, yz, xz, yz, Z * Z });
+            var xy = this.X * this.Y;
+            var xz = this.X * this.Z;
+            var yz = this.Y * this.Z;
+            return Matrix<double>.Build.Dense(3, 3, new[] { this.X * this.X, xy, xz, xy, this.Y * this.Y, yz, xz, yz, this.Z * this.Z });
         }
 
         /// <summary>
@@ -599,7 +599,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Angle SignedAngleTo(Vector3D v, UnitVector3D about)
         {
-            return SignedAngleTo(v.Normalize(), about);
+            return this.SignedAngleTo(v.Normalize(), about);
         }
 
         /// <summary>
@@ -611,7 +611,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Angle SignedAngleTo(UnitVector3D v, UnitVector3D about)
         {
-            if (IsParallelTo(about))
+            if (this.IsParallelTo(about))
             {
                 throw new ArgumentException("FromVector parallel to aboutVector");
             }
@@ -622,7 +622,7 @@ namespace MathNet.Spatial.Euclidean
             }
 
             var rp = new Plane(new Point3D(0, 0, 0), about);
-            var pfv = ProjectOn(rp).Direction;
+            var pfv = this.ProjectOn(rp).Direction;
             var ptv = v.ProjectOn(rp).Direction;
             var dp = pfv.DotProduct(ptv);
             if (Math.Abs(dp - 1) < 1E-15)
@@ -650,7 +650,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Angle AngleTo(Vector3D v)
         {
-            return AngleTo(v.Normalize());
+            return this.AngleTo(v.Normalize());
         }
 
         /// <summary>
@@ -661,7 +661,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Angle AngleTo(UnitVector3D v)
         {
-            var dp = DotProduct(v);
+            var dp = this.DotProduct(v);
             var angle = Math.Acos(dp);
             return Angle.FromRadians(angle);
         }
@@ -686,7 +686,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Point3D ToPoint3D()
         {
-            return new Point3D(X, Y, Z);
+            return new Point3D(this.X, this.Y, this.Z);
         }
 
         /// <summary>
@@ -696,7 +696,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D ToVector3D()
         {
-            return new Vector3D(X, Y, Z);
+            return new Vector3D(this.X, this.Y, this.Z);
         }
 
         /// <summary>
@@ -707,7 +707,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D TransformBy(CoordinateSystem coordinateSystem)
         {
-            return coordinateSystem.Transform(ToVector3D());
+            return coordinateSystem.Transform(this.ToVector3D());
         }
 
         /// <summary>
@@ -718,7 +718,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector3D TransformBy(Matrix<double> m)
         {
-            return Vector3D.OfVector(m.Multiply(ToVector()));
+            return Vector3D.OfVector(m.Multiply(this.ToVector()));
         }
 
         /// <summary>
@@ -728,14 +728,14 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { X, Y, Z });
+            return Vector<double>.Build.Dense(new[] { this.X, this.Y, this.Z });
         }
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return ToString("G15", CultureInfo.InvariantCulture);
+            return this.ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -746,7 +746,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public string ToString(IFormatProvider provider)
         {
-            return ToString("G15", provider);
+            return this.ToString("G15", provider);
         }
 
         /// <inheritdoc/>
@@ -755,7 +755,7 @@ namespace MathNet.Spatial.Euclidean
         {
             var numberFormatInfo = provider != null ? NumberFormatInfo.GetInstance(provider) : CultureInfo.InvariantCulture.NumberFormat;
             var separator = numberFormatInfo.NumberDecimalSeparator == "," ? ";" : ",";
-            return string.Format("({0}{1} {2}{1} {3})", X.ToString(format, numberFormatInfo), separator, Y.ToString(format, numberFormatInfo), Z.ToString(format, numberFormatInfo));
+            return string.Format("({0}{1} {2}{1} {3})", this.X.ToString(format, numberFormatInfo), separator, this.Y.ToString(format, numberFormatInfo), this.Z.ToString(format, numberFormatInfo));
         }
 
         /// <summary>
@@ -772,9 +772,9 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - X) < tolerance &&
-                   Math.Abs(other.Y - Y) < tolerance &&
-                   Math.Abs(other.Z - Z) < tolerance;
+            return Math.Abs(other.X - this.X) < tolerance &&
+                   Math.Abs(other.Y - this.Y) < tolerance &&
+                   Math.Abs(other.Z - this.Z) < tolerance;
         }
 
         /// <summary>
@@ -791,35 +791,35 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - X) < tolerance &&
-                   Math.Abs(other.Y - Y) < tolerance &&
-                   Math.Abs(other.Z - Z) < tolerance;
+            return Math.Abs(other.X - this.X) < tolerance &&
+                   Math.Abs(other.Y - this.Y) < tolerance &&
+                   Math.Abs(other.Z - this.Z) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(Vector3D other)
         {
-            return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
         }
 
         /// <inheritdoc />
         [Pure]
         public bool Equals(UnitVector3D other)
         {
-            return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
+            return this.X.Equals(other.X) && this.Y.Equals(other.Y) && this.Z.Equals(other.Z);
         }
 
         /// <inheritdoc />
         [Pure]
         public override bool Equals(object obj)
         {
-            return (obj is UnitVector3D u && Equals(u)) || (obj is Vector3D v && Equals(v));
+            return (obj is UnitVector3D u && this.Equals(u)) || (obj is Vector3D v && this.Equals(v));
         }
 
         /// <inheritdoc/>
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(X, Y, Z);
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y, this.Z);
 
         /// <inheritdoc />
         XmlSchema IXmlSerializable.GetSchema()
@@ -861,15 +861,15 @@ namespace MathNet.Spatial.Euclidean
                 return;
             }
 
-            throw new XmlException($"Could not read a {GetType()}");
+            throw new XmlException($"Could not read a {this.GetType()}");
         }
 
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteAttribute("X", X);
-            writer.WriteAttribute("Y", Y);
-            writer.WriteAttribute("Z", Z);
+            writer.WriteAttribute("X", this.X);
+            writer.WriteAttribute("Y", this.Y);
+            writer.WriteAttribute("Z", this.Z);
         }
 
         /// <summary>
@@ -880,7 +880,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         internal double DotProduct(Point3D v)
         {
-            return (X * v.X) + (Y * v.Y) + (Z * v.Z);
+            return (this.X * v.X) + (this.Y * v.Y) + (this.Z * v.Z);
         }
     }
 }

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -34,8 +34,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="y">The y component.</param>
         public Vector2D(double x, double y)
         {
-            this.X = x;
-            this.Y = y;
+            X = x;
+            Y = y;
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace MathNet.Spatial.Euclidean
         /// Gets the length of the vector
         /// </summary>
         [Pure]
-        public double Length => Math.Sqrt((this.X * this.X) + (this.Y * this.Y));
+        public double Length => Math.Sqrt((X * X) + (Y * Y));
 
         /// <summary>
         /// Gets a vector orthogonal to this
@@ -62,7 +62,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                return new Vector2D(-this.Y, this.X);
+                return new Vector2D(-Y, X);
             }
         }
 
@@ -255,7 +255,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Vector2D other, double tolerance = 1e-10)
         {
-            var dp = Math.Abs(this.Normalize().DotProduct(other.Normalize()));
+            var dp = Math.Abs(Normalize().DotProduct(other.Normalize()));
             return Math.Abs(1 - dp) <= tolerance;
         }
 
@@ -269,7 +269,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsParallelTo(Vector2D other, Angle tolerance)
         {
             // Compute the angle between these vectors
-            var angle = this.AngleTo(other);
+            var angle = AngleTo(other);
             if (angle < tolerance)
             {
                 return true;
@@ -291,7 +291,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsPerpendicularTo(Vector2D other, double tolerance = 1e-10)
         {
-            return Math.Abs(this.Normalize().DotProduct(other.Normalize())) < tolerance;
+            return Math.Abs(Normalize().DotProduct(other.Normalize())) < tolerance;
         }
 
         /// <summary>
@@ -303,7 +303,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsPerpendicularTo(Vector2D other, Angle tolerance)
         {
-            var angle = this.AngleTo(other);
+            var angle = AngleTo(other);
             const double Perpendicular = Math.PI / 2;
             return Math.Abs(angle.Radians - Perpendicular) < tolerance.Radians;
         }
@@ -319,7 +319,7 @@ namespace MathNet.Spatial.Euclidean
         public Angle SignedAngleTo(Vector2D other, bool clockWise = false, bool returnNegative = false)
         {
             var sign = clockWise ? -1 : 1;
-            var a1 = Math.Atan2(this.Y, this.X);
+            var a1 = Math.Atan2(Y, X);
             if (a1 < 0)
             {
                 a1 += 2 * Math.PI;
@@ -356,8 +356,8 @@ namespace MathNet.Spatial.Euclidean
             return Angle.FromRadians(
                 Math.Abs(
                     Math.Atan2(
-                        (this.X * other.Y) - (other.X * this.Y),
-                        (this.X * other.X) + (this.Y * other.Y))));
+                        (X * other.Y) - (other.X * Y),
+                        (X * other.X) + (Y * other.Y))));
         }
 
         /// <summary>
@@ -370,8 +370,8 @@ namespace MathNet.Spatial.Euclidean
         {
             var cs = Math.Cos(angle.Radians);
             var sn = Math.Sin(angle.Radians);
-            var x = (this.X * cs) - (this.Y * sn);
-            var y = (this.X * sn) + (this.Y * cs);
+            var x = (X * cs) - (Y * sn);
+            var y = (X * sn) + (Y * cs);
             return new Vector2D(x, y);
         }
 
@@ -383,22 +383,22 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DotProduct(Vector2D other)
         {
-            return (this.X * other.X) + (this.Y * other.Y);
+            return (X * other.X) + (Y * other.Y);
         }
 
         /// <summary>
         /// Performs the 2D 'cross product' as if the 2D vectors were really 3D vectors in the z=0 plane, returning
         /// the scalar magnitude and direction of the resulting z value.
-        /// Formula: (this.X * other.Y) - (this.Y * other.X)
+        /// Formula: (X * other.Y) - (Y * other.X)
         /// </summary>
         /// <param name="other">The other <see cref="Vector2D"/></param>
-        /// <returns>(this.X * other.Y) - (this.Y * other.X)</returns>
+        /// <returns>(X * other.Y) - (Y * other.X)</returns>
         [Pure]
         public double CrossProduct(Vector2D other)
         {
             // Though the cross product is undefined in 2D space, this is a useful mathematical operation to
             // determine angular direction and to compute the area of 2D shapes
-            return (this.X * other.Y) - (this.Y * other.X);
+            return (X * other.Y) - (Y * other.X);
         }
 
         /// <summary>
@@ -409,7 +409,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D ProjectOn(Vector2D other)
         {
-            return other * (this.DotProduct(other) / other.DotProduct(other));
+            return other * (DotProduct(other) / other.DotProduct(other));
         }
 
         /// <summary>
@@ -419,8 +419,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D Normalize()
         {
-            var l = this.Length;
-            return new Vector2D(this.X / l, this.Y / l);
+            var l = Length;
+            return new Vector2D(X / l, Y / l);
         }
 
         /// <summary>
@@ -431,7 +431,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D ScaleBy(double d)
         {
-            return new Vector2D(d * this.X, d * this.Y);
+            return new Vector2D(d * X, d * Y);
         }
 
         /// <summary>
@@ -441,7 +441,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D Negate()
         {
-            return new Vector2D(-1 * this.X, -1 * this.Y);
+            return new Vector2D(-1 * X, -1 * Y);
         }
 
         /// <summary>
@@ -452,7 +452,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D Subtract(Vector2D v)
         {
-            return new Vector2D(this.X - v.X, this.Y - v.Y);
+            return new Vector2D(X - v.X, Y - v.Y);
         }
 
         /// <summary>
@@ -463,7 +463,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D Add(Vector2D v)
         {
-            return new Vector2D(this.X + v.X, this.Y + v.Y);
+            return new Vector2D(X + v.X, Y + v.Y);
         }
 
         /// <summary>
@@ -474,7 +474,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D TransformBy(Matrix<double> m)
         {
-            var transformed = m.Multiply(this.ToVector());
+            var transformed = m.Multiply(ToVector());
             return new Vector2D(transformed.At(0), transformed.At(1));
         }
 
@@ -485,7 +485,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { this.X, this.Y });
+            return Vector<double>.Build.Dense(new[] { X, Y });
         }
 
         /// <summary>
@@ -502,27 +502,27 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - this.X) < tolerance &&
-                   Math.Abs(other.Y - this.Y) < tolerance;
+            return Math.Abs(other.X - X) < tolerance &&
+                   Math.Abs(other.Y - Y) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
-        public bool Equals(Vector2D other) => this.X.Equals(other.X) && this.Y.Equals(other.Y);
+        public bool Equals(Vector2D other) => X.Equals(other.X) && Y.Equals(other.Y);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Vector2D v && this.Equals(v);
+        public override bool Equals(object obj) => obj is Vector2D v && Equals(v);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(this.X, this.Y);
+        public override int GetHashCode() => HashCode.Combine(X, Y);
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return this.ToString("G15", CultureInfo.InvariantCulture);
+            return ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -533,7 +533,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public string ToString(IFormatProvider provider)
         {
-            return this.ToString("G15", provider);
+            return ToString("G15", provider);
         }
 
         /// <inheritdoc />
@@ -542,7 +542,7 @@ namespace MathNet.Spatial.Euclidean
         {
             var numberFormatInfo = provider != null ? NumberFormatInfo.GetInstance(provider) : CultureInfo.InvariantCulture.NumberFormat;
             var separator = numberFormatInfo.NumberDecimalSeparator == "," ? ";" : ",";
-            return $"({this.X.ToString(format, numberFormatInfo)}{separator}\u00A0{this.Y.ToString(format, numberFormatInfo)})";
+            return $"({X.ToString(format, numberFormatInfo)}{separator}\u00A0{Y.ToString(format, numberFormatInfo)})";
         }
 
         /// <inheritdoc />
@@ -575,8 +575,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteAttribute("X", this.X);
-            writer.WriteAttribute("Y", this.Y);
+            writer.WriteAttribute("X", X);
+            writer.WriteAttribute("Y", Y);
         }
     }
 }

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -34,8 +34,8 @@ namespace MathNet.Spatial.Euclidean
         /// <param name="y">The y component.</param>
         public Vector2D(double x, double y)
         {
-            X = x;
-            Y = y;
+            this.X = x;
+            this.Y = y;
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace MathNet.Spatial.Euclidean
         /// Gets the length of the vector
         /// </summary>
         [Pure]
-        public double Length => Math.Sqrt((X * X) + (Y * Y));
+        public double Length => Math.Sqrt((this.X * this.X) + (this.Y * this.Y));
 
         /// <summary>
         /// Gets a vector orthogonal to this
@@ -62,7 +62,7 @@ namespace MathNet.Spatial.Euclidean
         {
             get
             {
-                return new Vector2D(-Y, X);
+                return new Vector2D(-this.Y, this.X);
             }
         }
 
@@ -255,7 +255,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsParallelTo(Vector2D other, double tolerance = 1e-10)
         {
-            var dp = Math.Abs(Normalize().DotProduct(other.Normalize()));
+            var dp = Math.Abs(this.Normalize().DotProduct(other.Normalize()));
             return Math.Abs(1 - dp) <= tolerance;
         }
 
@@ -269,7 +269,7 @@ namespace MathNet.Spatial.Euclidean
         public bool IsParallelTo(Vector2D other, Angle tolerance)
         {
             // Compute the angle between these vectors
-            var angle = AngleTo(other);
+            var angle = this.AngleTo(other);
             if (angle < tolerance)
             {
                 return true;
@@ -291,7 +291,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsPerpendicularTo(Vector2D other, double tolerance = 1e-10)
         {
-            return Math.Abs(Normalize().DotProduct(other.Normalize())) < tolerance;
+            return Math.Abs(this.Normalize().DotProduct(other.Normalize())) < tolerance;
         }
 
         /// <summary>
@@ -303,7 +303,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public bool IsPerpendicularTo(Vector2D other, Angle tolerance)
         {
-            var angle = AngleTo(other);
+            var angle = this.AngleTo(other);
             const double Perpendicular = Math.PI / 2;
             return Math.Abs(angle.Radians - Perpendicular) < tolerance.Radians;
         }
@@ -319,7 +319,7 @@ namespace MathNet.Spatial.Euclidean
         public Angle SignedAngleTo(Vector2D other, bool clockWise = false, bool returnNegative = false)
         {
             var sign = clockWise ? -1 : 1;
-            var a1 = Math.Atan2(Y, X);
+            var a1 = Math.Atan2(this.Y, this.X);
             if (a1 < 0)
             {
                 a1 += 2 * Math.PI;
@@ -356,8 +356,8 @@ namespace MathNet.Spatial.Euclidean
             return Angle.FromRadians(
                 Math.Abs(
                     Math.Atan2(
-                        (X * other.Y) - (other.X * Y),
-                        (X * other.X) + (Y * other.Y))));
+                        (this.X * other.Y) - (other.X * this.Y),
+                        (this.X * other.X) + (this.Y * other.Y))));
         }
 
         /// <summary>
@@ -370,8 +370,8 @@ namespace MathNet.Spatial.Euclidean
         {
             var cs = Math.Cos(angle.Radians);
             var sn = Math.Sin(angle.Radians);
-            var x = (X * cs) - (Y * sn);
-            var y = (X * sn) + (Y * cs);
+            var x = (this.X * cs) - (this.Y * sn);
+            var y = (this.X * sn) + (this.Y * cs);
             return new Vector2D(x, y);
         }
 
@@ -383,22 +383,22 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public double DotProduct(Vector2D other)
         {
-            return (X * other.X) + (Y * other.Y);
+            return (this.X * other.X) + (this.Y * other.Y);
         }
 
         /// <summary>
         /// Performs the 2D 'cross product' as if the 2D vectors were really 3D vectors in the z=0 plane, returning
         /// the scalar magnitude and direction of the resulting z value.
-        /// Formula: (X * other.Y) - (Y * other.X)
+        /// Formula: (this.X * other.Y) - (this.Y * other.X)
         /// </summary>
         /// <param name="other">The other <see cref="Vector2D"/></param>
-        /// <returns>(X * other.Y) - (Y * other.X)</returns>
+        /// <returns>(this.X * other.Y) - (this.Y * other.X)</returns>
         [Pure]
         public double CrossProduct(Vector2D other)
         {
             // Though the cross product is undefined in 2D space, this is a useful mathematical operation to
             // determine angular direction and to compute the area of 2D shapes
-            return (X * other.Y) - (Y * other.X);
+            return (this.X * other.Y) - (this.Y * other.X);
         }
 
         /// <summary>
@@ -409,7 +409,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D ProjectOn(Vector2D other)
         {
-            return other * (DotProduct(other) / other.DotProduct(other));
+            return other * (this.DotProduct(other) / other.DotProduct(other));
         }
 
         /// <summary>
@@ -419,8 +419,8 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D Normalize()
         {
-            var l = Length;
-            return new Vector2D(X / l, Y / l);
+            var l = this.Length;
+            return new Vector2D(this.X / l, this.Y / l);
         }
 
         /// <summary>
@@ -431,7 +431,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D ScaleBy(double d)
         {
-            return new Vector2D(d * X, d * Y);
+            return new Vector2D(d * this.X, d * this.Y);
         }
 
         /// <summary>
@@ -441,7 +441,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D Negate()
         {
-            return new Vector2D(-1 * X, -1 * Y);
+            return new Vector2D(-1 * this.X, -1 * this.Y);
         }
 
         /// <summary>
@@ -452,7 +452,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D Subtract(Vector2D v)
         {
-            return new Vector2D(X - v.X, Y - v.Y);
+            return new Vector2D(this.X - v.X, this.Y - v.Y);
         }
 
         /// <summary>
@@ -463,7 +463,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D Add(Vector2D v)
         {
-            return new Vector2D(X + v.X, Y + v.Y);
+            return new Vector2D(this.X + v.X, this.Y + v.Y);
         }
 
         /// <summary>
@@ -474,7 +474,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector2D TransformBy(Matrix<double> m)
         {
-            var transformed = m.Multiply(ToVector());
+            var transformed = m.Multiply(this.ToVector());
             return new Vector2D(transformed.At(0), transformed.At(1));
         }
 
@@ -485,7 +485,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public Vector<double> ToVector()
         {
-            return Vector<double>.Build.Dense(new[] { X, Y });
+            return Vector<double>.Build.Dense(new[] { this.X, this.Y });
         }
 
         /// <summary>
@@ -502,27 +502,27 @@ namespace MathNet.Spatial.Euclidean
                 throw new ArgumentException("epsilon < 0");
             }
 
-            return Math.Abs(other.X - X) < tolerance &&
-                   Math.Abs(other.Y - Y) < tolerance;
+            return Math.Abs(other.X - this.X) < tolerance &&
+                   Math.Abs(other.Y - this.Y) < tolerance;
         }
 
         /// <inheritdoc />
         [Pure]
-        public bool Equals(Vector2D other) => X.Equals(other.X) && Y.Equals(other.Y);
+        public bool Equals(Vector2D other) => this.X.Equals(other.X) && this.Y.Equals(other.Y);
 
         /// <inheritdoc />
         [Pure]
-        public override bool Equals(object obj) => obj is Vector2D v && Equals(v);
+        public override bool Equals(object obj) => obj is Vector2D v && this.Equals(v);
 
         /// <inheritdoc />
         [Pure]
-        public override int GetHashCode() => HashCode.Combine(X, Y);
+        public override int GetHashCode() => HashCode.Combine(this.X, this.Y);
 
         /// <inheritdoc />
         [Pure]
         public override string ToString()
         {
-            return ToString("G15", CultureInfo.InvariantCulture);
+            return this.ToString("G15", CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -533,7 +533,7 @@ namespace MathNet.Spatial.Euclidean
         [Pure]
         public string ToString(IFormatProvider provider)
         {
-            return ToString("G15", provider);
+            return this.ToString("G15", provider);
         }
 
         /// <inheritdoc />
@@ -542,7 +542,7 @@ namespace MathNet.Spatial.Euclidean
         {
             var numberFormatInfo = provider != null ? NumberFormatInfo.GetInstance(provider) : CultureInfo.InvariantCulture.NumberFormat;
             var separator = numberFormatInfo.NumberDecimalSeparator == "," ? ";" : ",";
-            return $"({X.ToString(format, numberFormatInfo)}{separator}\u00A0{Y.ToString(format, numberFormatInfo)})";
+            return $"({this.X.ToString(format, numberFormatInfo)}{separator}\u00A0{this.Y.ToString(format, numberFormatInfo)})";
         }
 
         /// <inheritdoc />
@@ -575,8 +575,8 @@ namespace MathNet.Spatial.Euclidean
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteAttribute("X", X);
-            writer.WriteAttribute("Y", Y);
+            writer.WriteAttribute("X", this.X);
+            writer.WriteAttribute("Y", this.Y);
         }
     }
 }

--- a/src/Spatial/Spatial.csproj.DotSettings
+++ b/src/Spatial/Spatial.csproj.DotSettings
@@ -1,6 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=2D/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=3D/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=internals_005Cavltreeset/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=internals_005Cconvexhull/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Obsolete/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Spatial/Spatial.csproj.DotSettings
+++ b/src/Spatial/Spatial.csproj.DotSettings
@@ -1,4 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=2D/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=3D/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=internals_005Cavltreeset/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=internals_005Cconvexhull/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=Obsolete/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
* Cleans up the test project namespaces
* Makes extended use of ```readonly struct```  whenever possible
* Removes redundant ```this.``` qualifier from files