### PR TITLE
Add Vector2D.ToPoint2D() method with unit test

### DIFF
--- a/src/Spatial.Tests/Euclidean/Point2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Point2DTests.cs
@@ -146,6 +146,13 @@ namespace MathNet.Spatial.Tests.Euclidean
             Assert.AreEqual(expected, p2.DistanceTo(p1));
         }
 
+        [TestCase("-1 ; 2")]
+        public void ToVectorAndBack(string ps)
+        {
+            var p = Point2D.Parse(ps);
+            AssertGeometry.AreEqual(p, p.ToVector2D().ToPoint2D(), 1e-9);
+        }
+
         [TestCase("0, 0", "1, 2", "0.5, 1")]
         [TestCase("-1, -2", "1, 2", "0, 0")]
         public void MidPoint(string p1s, string p2s, string eps)

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -476,6 +476,15 @@ namespace MathNet.Spatial.Euclidean
         }
 
         /// <summary>
+        /// Returns a point equivalent to the vector
+        /// </summary>
+        /// <returns>A point</returns>
+        public Point2D ToPoint2D()
+        {
+            return new Point2D(this.X, this.Y);
+        }
+
+        /// <summary>
         /// Transforms a vector by multiplying it against a provided matrix
         /// </summary>
         /// <param name="m">The matrix to multiply</param>

--- a/src/Spatial/Euclidean/Vector2D.cs
+++ b/src/Spatial/Euclidean/Vector2D.cs
@@ -476,7 +476,7 @@ namespace MathNet.Spatial.Euclidean
         }
 
         /// <summary>
-        /// Returns a point equivalent to the vector
+        /// Returns a point, whose position vector is equal to the current vector
         /// </summary>
         /// <returns>A point</returns>
         public Point2D ToPoint2D()

--- a/src/Spatial/Euclidean/Vector3D.cs
+++ b/src/Spatial/Euclidean/Vector3D.cs
@@ -523,7 +523,7 @@ namespace MathNet.Spatial.Euclidean
         }
 
         /// <summary>
-        /// Returns a point equivalent to the vector
+        /// Returns a point, whose position vector is equal to the current vector
         /// </summary>
         /// <returns>A point</returns>
         public Point3D ToPoint3D()


### PR DESCRIPTION
Similar method is present for Vector3D, so I added it to Vector2D too