### PR TITLE
Feat: Line2D.DistanceTo(Point2D p)

### DIFF
--- a/src/Spatial.Tests/Euclidean/Line2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Line2DTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
@@ -56,17 +56,32 @@ namespace MathNet.Spatial.Tests.Euclidean
             AssertGeometry.AreEqual(ex, line.Direction);
         }
 
-        [TestCase("-1,+1", "+1,+1", "0,0", 1.0)]
-        [TestCase("-1,+1", "+1,+1", "0,3", 2.0)]
-        [TestCase("-1,+1", "+1,+1", "0,1", 0.0)]
-        [TestCase("-1,0", "0,+1", "0,0", 0.70710678)]
-        [TestCase("-1,0", "0,+1", "-0.5,0.5", 0.0)]
-        [TestCase("+1,-1", "+1,+1", "0,0", 1.0)]
-        [TestCase("+1,-1", "+1,+1", "1,0", 0.0)]
-        [TestCase("+1,-1", "+1,+1", "3,0", 2.0)]
-        public void DistanceFromLineToPoint(string p1s, string p2s, string ps, double expectedDistance)
+        public static object[] DistanceTestCases =
         {
-            var line = new Line2D(Point2D.Parse(p1s), Point2D.Parse(p2s));
+            new object[] { "-1,+1", "+1,+1", "0,0", 1.0 },
+            new object[] { "-1,+1", "+1,+1", "0,3", 2.0 },
+            new object[] { "-1,+1", "+1,+1", "0,1", 0.0 },
+            new object[] { "-1,0", "0,+1", "0,0", 0.70710678 },
+            new object[] { "-1,0", "0,+1", "-0.5,0.5", 0.0 },
+            new object[] { "+1,-1", "+1,+1", "0,0", 1.0 },
+            new object[] { "+1,-1", "+1,+1", "1,0", 0.0 },
+            new object[] { "+1,-1", "+1,+1", "3,0", 2.0 },
+        };
+
+        [TestCaseSource(nameof(DistanceTestCases))]
+        public void DistanceFromLineToPoint(string sp1, string sp2, string ps, double expectedDistance)
+        {
+            var line = new Line2D(Point2D.Parse(sp1), Point2D.Parse(sp2));
+            var p = Point2D.Parse(ps);
+
+            var actual = line.DistanceTo(p);
+            Assert.That(actual, Is.EqualTo(expectedDistance).Within(1e-6));
+        }
+
+        [TestCaseSource(nameof(DistanceTestCases))]
+        public void DistanceFromLineToPoint_SwappedP1sAndP2s(string sp1, string sp2, string ps, double expectedDistance)
+        {
+            var line = new Line2D(Point2D.Parse(sp2), Point2D.Parse(sp1)); // swapped
             var p = Point2D.Parse(ps);
 
             var actual = line.DistanceTo(p);

--- a/src/Spatial.Tests/Euclidean/Line2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Line2DTests.cs
@@ -56,6 +56,20 @@ namespace MathNet.Spatial.Tests.Euclidean
             AssertGeometry.AreEqual(ex, line.Direction);
         }
 
+        [TestCase("-1,+1", "+1,+1", "0,0", 1.0)]
+        [TestCase("-1,+1", "+1,+1", "0,3", 2.0)]
+        [TestCase("-1,0", "0,+1", "0,0", 0.70710678)]
+        [TestCase("+1,-1", "+1,+1", "0,0", 1.0)]
+        [TestCase("+1,-1", "+1,+1", "3,0", 2.0)]
+        public void DistanceFromLineToPoint(string p1s, string p2s, string ps, double expectedDistance)
+        {
+            var line = new Line2D(Point2D.Parse(p1s), Point2D.Parse(p2s));
+            var p = Point2D.Parse(ps);
+
+            var actual = line.DistanceTo(p);
+            Assert.That(actual, Is.EqualTo(expectedDistance).Within(1e-6));
+        }
+
         [TestCase("0,0", "10,10", "0,0", "10,10", true)]
         [TestCase("0,0", "10,10", "0,0", "10,11", false)]
         public void EqualityOperator(string p1s, string p2s, string p3s, string p4s, bool expected)

--- a/src/Spatial.Tests/Euclidean/Line2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Line2DTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using MathNet.Spatial.Euclidean;
 using MathNet.Spatial.Units;
 using NUnit.Framework;
@@ -56,32 +56,17 @@ namespace MathNet.Spatial.Tests.Euclidean
             AssertGeometry.AreEqual(ex, line.Direction);
         }
 
-        public static object[] DistanceTestCases =
+        [TestCase("-1,+1", "+1,+1", "0,0", 1.0)]
+        [TestCase("-1,+1", "+1,+1", "0,3", 2.0)]
+        [TestCase("-1,+1", "+1,+1", "0,1", 0.0)]
+        [TestCase("-1,0", "0,+1", "0,0", 0.70710678)]
+        [TestCase("-1,0", "0,+1", "-0.5,0.5", 0.0)]
+        [TestCase("+1,-1", "+1,+1", "0,0", 1.0)]
+        [TestCase("+1,-1", "+1,+1", "1,0", 0.0)]
+        [TestCase("+1,-1", "+1,+1", "3,0", 2.0)]
+        public void DistanceFromLineToPoint(string p1s, string p2s, string ps, double expectedDistance)
         {
-            new object[] { "-1,+1", "+1,+1", "0,0", 1.0 },
-            new object[] { "-1,+1", "+1,+1", "0,3", 2.0 },
-            new object[] { "-1,+1", "+1,+1", "0,1", 0.0 },
-            new object[] { "-1,0", "0,+1", "0,0", 0.70710678 },
-            new object[] { "-1,0", "0,+1", "-0.5,0.5", 0.0 },
-            new object[] { "+1,-1", "+1,+1", "0,0", 1.0 },
-            new object[] { "+1,-1", "+1,+1", "1,0", 0.0 },
-            new object[] { "+1,-1", "+1,+1", "3,0", 2.0 },
-        };
-
-        [TestCaseSource(nameof(DistanceTestCases))]
-        public void DistanceFromLineToPoint(string sp1, string sp2, string ps, double expectedDistance)
-        {
-            var line = new Line2D(Point2D.Parse(sp1), Point2D.Parse(sp2));
-            var p = Point2D.Parse(ps);
-
-            var actual = line.DistanceTo(p);
-            Assert.That(actual, Is.EqualTo(expectedDistance).Within(1e-6));
-        }
-
-        [TestCaseSource(nameof(DistanceTestCases))]
-        public void DistanceFromLineToPoint_SwappedP1sAndP2s(string sp1, string sp2, string ps, double expectedDistance)
-        {
-            var line = new Line2D(Point2D.Parse(sp2), Point2D.Parse(sp1)); // swapped
+            var line = new Line2D(Point2D.Parse(p1s), Point2D.Parse(p2s));
             var p = Point2D.Parse(ps);
 
             var actual = line.DistanceTo(p);

--- a/src/Spatial.Tests/Euclidean/Line2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Line2DTests.cs
@@ -58,8 +58,11 @@ namespace MathNet.Spatial.Tests.Euclidean
 
         [TestCase("-1,+1", "+1,+1", "0,0", 1.0)]
         [TestCase("-1,+1", "+1,+1", "0,3", 2.0)]
+        [TestCase("-1,+1", "+1,+1", "0,1", 0.0)]
         [TestCase("-1,0", "0,+1", "0,0", 0.70710678)]
+        [TestCase("-1,0", "0,+1", "-0.5,0.5", 0.0)]
         [TestCase("+1,-1", "+1,+1", "0,0", 1.0)]
+        [TestCase("+1,-1", "+1,+1", "1,0", 0.0)]
         [TestCase("+1,-1", "+1,+1", "3,0", 2.0)]
         public void DistanceFromLineToPoint(string p1s, string p2s, string ps, double expectedDistance)
         {

--- a/src/Spatial.Tests/Euclidean/Line2DTests.cs
+++ b/src/Spatial.Tests/Euclidean/Line2DTests.cs
@@ -64,6 +64,14 @@ namespace MathNet.Spatial.Tests.Euclidean
         [TestCase("+1,-1", "+1,+1", "0,0", 1.0)]
         [TestCase("+1,-1", "+1,+1", "1,0", 0.0)]
         [TestCase("+1,-1", "+1,+1", "3,0", 2.0)]
+        [TestCase("+1,+1", "-1,+1", "0,0", 1.0)]
+        [TestCase("+1,+1", "-1,+1", "0,3", 2.0)]
+        [TestCase("+1,+1", "-1,+1", "0,1", 0.0)]
+        [TestCase("0,+1", "-1,0", "0,0", 0.70710678)]
+        [TestCase("0,+1", "-1,0", "-0.5,0.5", 0.0)]
+        [TestCase("+1,+1", "+1,-1", "0,0", 1.0)]
+        [TestCase("+1,+1", "+1,-1", "1,0", 0.0)]
+        [TestCase("+1,+1", "+1,-1", "3,0", 2.0)]
         public void DistanceFromLineToPoint(string p1s, string p2s, string ps, double expectedDistance)
         {
             var line = new Line2D(Point2D.Parse(p1s), Point2D.Parse(p2s));

--- a/src/Spatial/Euclidean/Line2D.cs
+++ b/src/Spatial/Euclidean/Line2D.cs
@@ -124,6 +124,19 @@ namespace MathNet.Spatial.Euclidean
         }
 
         /// <summary>
+        /// Returns the straight line Distance to the given point.
+        /// </summary>
+        /// <param name="p">the given point</param>
+        /// <returns>a distance measure</returns>
+        [Pure]
+        public double DistanceTo(Point2D p)
+        {
+            var closestPoint = ClosestPointTo(p, false); // this is Line2D, not LineSegment2D.
+            var result = closestPoint.DistanceTo(p);
+            return result;
+        }
+
+        /// <summary>
         /// Returns the shortest line between this line and a point.
         /// </summary>
         /// <param name="p">the point to create a line to</param>


### PR DESCRIPTION
I implemented `Line2D.DistanceTo(Point2D p)` which calculates the distance from `this` line to the given point `p`.
This method should always return the value of 0 or positive.

It will be nice if we can discuss whether the testcases is sufficient.
